### PR TITLE
Updates to Snakefile and bug fixes; TSV file improvements; Summary stats in QC

### DIFF
--- a/Rmd/DESeq2_report.rnaseq.Rmd
+++ b/Rmd/DESeq2_report.rnaseq.Rmd
@@ -21,6 +21,7 @@ params:
   cpus: 12 # Set to a lower number (e.g., 2 to 4) if you aren't working in a server environment
   run_pathway_analysis: TRUE # Optionally disable pathway analysis if not available for your organism
   wikipathways_directory: "~/shared/dbs/wikipathways"
+  wikipathways_filename: "wikipathways-20210810-gmt-Homo_sapiens.gmt"
   biospyder_dbs: "~/shared/dbs/biospyder/"
   biospyder_manifest_file: "190603 Mouse Whole Transcriptome 1.1 Manifest.txt"
   nBestFeatures: 20 # The number of best features to make plots of their counts

--- a/Rmd/DESeq2_report.rnaseq.Rmd
+++ b/Rmd/DESeq2_report.rnaseq.Rmd
@@ -248,15 +248,9 @@ digits = 2 # For rounding numbers
 #### FILES TO LOAD
 ################################################################################
 ################################################################################
-# A. Tab delimited file with merged RSEM.genes.results files:
-if (Platform == "TempO-Seq") {
-  SampleDataFile <- file.path(paths$processed, "count_table.tsv")
-  sampledata_sep = ","
-} else {
-  SampleDataFile <- file.path(paths$processed, "genes.data.tsv")
-  sampledata_sep = "\t"
-}
-  
+# A. Tab delimited file for genes by counts matrix:
+SampleDataFile <- file.path(paths$processed, "count_table.tsv")
+
 # B. Tab delimited sample information file with at least 2 columns:
   # 1. sample names identical to the column names of sampleData
   # 2. compound/group/whatever (needs to identify to which experimental group the sample belongs)
@@ -279,7 +273,7 @@ The code above (not shown by default) specifies user preferences and data locati
 # Load input files
 message(paste("loading data from ", SampleDataFile))
 sampleData <- read.delim(SampleDataFile,
-                         sep = sampledata_sep,
+                         sep = "\t",
                          stringsAsFactors = FALSE,
                          header = TRUE, 
                          quote = "\"",

--- a/Rmd/DESeq2_report.rnaseq.Rmd
+++ b/Rmd/DESeq2_report.rnaseq.Rmd
@@ -10,6 +10,7 @@ params:
   group_facet: "chemical"       #null # If you have many different experimental groups, you may subset the report by specifying a column in the metadata to filter groups, and then setting the group of interest in group_filter
   group_filter:  "BitA"       # null # Which group will this report be done on?
   dose: "dose"                   # Explictly define if there is a dose column in the experiment. Note: this *can* be different from the sortcol, which is why we include both.
+  sortcol: "dose"   # Column used to sort the data
   lenient_contrasts: FALSE         # Use either column (exp, cont) of contrasts file to limit what is included in the report (instead of just exp column)
   strict_contrasts: FALSE         # Use BOTH columns (exp, cont) of contrasts file to limit what is included in the report
   exclude_samples: !r NA  # Optionally, a vector of sample names to exclude from the analysis

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -8,7 +8,6 @@ params:
   nmr_threshold: 100000    # 10% of 1M reads for TempOSeq = 100,000; 10% of 10M reads for RNA-Seq = 1,000,000.
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
   gini_cutoff: 0.95
-  sampledata_sep: ","     # Comma for TempO-Seq, Maybe tabs for RNASeq, customize!
     value:
     one: ["chemical", "dose"]
     two: ["I7_Index_ID", "I5_Index_ID"] 

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -8,10 +8,11 @@ params:
   nmr_threshold: 100000    # 10% of 1M reads for TempOSeq = 100,000; 10% of 10M reads for RNA-Seq = 1,000,000.
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
   gini_cutoff: 0.95
+  groups:
     value:
-    one: ["chemical", "dose"]
-    two: ["I7_Index_ID", "I5_Index_ID"] 
-    three: ["row", "column"]
+      one: ["chemical", "dose"]
+      two: ["I7_Index_ID", "I5_Index_ID"]
+      three: ["row", "column"]
     #4: ["batch"]
     #As many groups as desired...
   batch_var: "batch"          # "batch"

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -568,13 +568,8 @@ d %>%
 Samples less than `r align_threshold` aligned reads removed.
 
 ```{r fraction_mapped_reads}
-if (Platform == "TempO-Seq") {
-  FMR_df <- rownames_to_column(mu) %>% mutate(FMR = pct_mapped) %>% dplyr::select(rowname,FMR)
-  QAQC <- QAQC %>% left_join(FMR_df, QAQC, by=c("Sample" = "rowname"))
-} else {
-  QAQC <- QAQC %>% left_join(mu, by = "Sample")
-}
-  failed_alignment_threshold <- QAQC[QAQC$FMR < align_threshold,]
+QAQC <- QAQC %>% left_join(mu, by = "Sample")
+failed_alignment_threshold <- QAQC[QAQC$FMR < align_threshold,]
   
 # Samples failing
 d %>%

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -244,6 +244,28 @@ if (file.exists(remove_file)) {
 }
 ```
 
+# Summary Statistics
+
+Below, you will find plots and a table showing the distribution of read metrics (quality, GC content, aligned reads, etc.).
+
+```{r summary-stats}
+summary_stats <- pivot_longer(multiqc_general_stats, cols = -Sample)
+stat_metrics <- summary_stats %>%
+  group_by(name) %>%
+  summarise(Mean=mean(value), Median=median(value))
+ggplot(summary_stats, aes(x=name, y=value)) +
+  geom_violin() +
+  geom_jitter(alpha = 0.5) +
+  facet_wrap(name~., scales = "free")
+
+stat_metrics %>%
+  kable(caption = "Summary statistics from the alignments for all samples") %>%
+  kable_styling(bootstrap_options = "striped", full_width = F, position = "left") %>%
+  scroll_box(width = "100%", height = "480px")
+
+
+```
+
 # Sample Filtering Code
 
 ## Samples Removed Manually

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -1428,7 +1428,7 @@ plot_batches + geom_boxplot(aes(y = Nsig80_data)) + ggtitle("Proportion of probe
 
 ### Dose effects
 
-```{r plot_chemical_differences, eval=!is.na(params$dose), fig.height = as.numeric(custom_fig_height)*0.75}
+```{r plot_chemical_differences, eval=!is.na(params$dose), fig.height = as.numeric(custom_fig_height)*1.5}
 # It would make sense to use params$dose instead of dose here - but ensym() doesn't want to evaluate it properly? Error: arg must be of length 1 - maybe because it's part of a list? Early on, dose <- params$dose sets it to a character vector, maybe the class is interpreted differently by ensym().
 plot_dose_effect <- ggplot(QAQC_annotated, aes(x = factor(!!ensym(dose)), color = factor(!!ensym(dose)))) +
   facet_wrap(paste0("~",treatment_var), scales = "free") +

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -89,7 +89,6 @@ dendro_color_by <- params$dendro_color_by
 nmr_threshold <- params$nmr_threshold
 align_threshold <- params$align_threshold
 gini_cutoff <- params$gini_cutoff
-sampledata_sep <- params$sampledata_sep
 groups <- params$groups
 #groups[[2]]: c("I7_Index_ID","I5_Index_ID")
 #groups[[3]]: c("Row","Column")
@@ -131,66 +130,43 @@ knitr::opts_chunk$set(warning = FALSE, message = FALSE)
 ############################################################################
 
 # A. File with read counts
-if (Platform == "TempO-Seq") {
-    SampleDataFile <- file.path(paths$processed,"count_table.tsv")
-    MappedUnmapped <- file.path(paths$processed,"mapped_unmapped.tsv")
-    sampledata_sep <- "\t"
-    collapse_reps <- function(filepath){
-      df <- read.table(file = filepath,
-                       sep = "\t",
-                       header = T)
-      names(df) = gsub(pattern = "_trimmed", replacement = "", x = names(df))
-      df <- df %>% pivot_longer(cols = -c("X"),
-                                names_to = c('.value','flowcell'),
-                                names_pattern = '(.*)_(.*)')
-      df[is.na(df)] <- 0
-      sampleDataTable <- data.table(df %>% dplyr::select(-c(flowcell)))
-      results <- sampleDataTable[, lapply(.SD,sum), by = "X"]
-      return(results)
-    }
-    if (params$collapse_replicates == T) {
-      sampleData <- collapse_reps(SampleDataFile)
-      write.table(sampleData,
-                  file = file.path(paths$processed,"count_table_collapsed.tsv"),
-                  sep = "\t",
-                  quote = F,
-                  row.names = F)
-      mu <- collapse_reps(MappedUnmapped)
-      write.table(mu,
-                  file = file.path(paths$processed,"mapped_unmapped_collapsed.tsv"),
-                  sep = "\t",
-                  quote = F,
-                  row.names = F)
-    } else {
-      sampleData <- read.table(file.path(paths$processed,"count_table.tsv"),
-                             sep = sampledata_sep,
-                             stringsAsFactors = FALSE,
-                             header = TRUE,
-                             quote = "\"",
-                             row.names = 1,
-                             check.names = FALSE)
-      mu <- read.table(file.path(paths$processed,"mapped_unmapped.tsv"),
-                     sep = "\t",
-                     header = T,
-                     row.names = 1,
-                     stringsAsFactors = F,
-                     check.names = F)  
-      }
-    mu <- as.data.frame(t(mu))
-    mu$pct_mapped <- mu$mapped/(mu$mapped + mu$unmapped)
-  } else {
-    SampleDataFile <- file.path(paths$processed,"genes.data.tsv")
-    sampleData <- read.table(SampleDataFile,
-                             sep = sampledata_sep,
-                             stringsAsFactors = FALSE,
-                             header = TRUE,
-                             quote = "\"",
-                             row.names = 1,
-                             check.names = FALSE)
-    multiQCFile <- file.path(paths$qc, "MultiQC_Report_data.zip")
-    multiqc_general_stats <- read.table(unz(multiQCFile, 'multiqc_general_stats.txt'), header = TRUE, sep = "\t") 
-    mu <- data.frame(Sample = multiqc_general_stats$Sample, FMR = multiqc_general_stats$STAR_mqc.generalstats.star.uniquely_mapped_percent/100)
+SampleDataFile <- file.path(paths$processed,"count_table.tsv")
+if (params$collapse_replicates == T) {
+  collapse_reps <- function(filepath) {
+  df <- read.table(file = filepath,
+                   sep = "\t",
+                   header = T)
+  names(df) = gsub(pattern = "_trimmed", replacement = "", x = names(df))
+  df <- df %>% pivot_longer(cols = -c("X"),
+                            names_to = c('.value','flowcell'),
+                            names_pattern = '(.*)_(.*)')
+  df[is.na(df)] <- 0
+  sampleDataTable <- data.table(df %>% dplyr::select(-c(flowcell)))
+  results <- sampleDataTable[, lapply(.SD,sum), by = "X"]
+  return(results)
   }
+  sampleData <- collapse_reps(SampleDataFile)
+  write.table(sampleData,
+              file = file.path(paths$processed,"count_table_collapsed.tsv"),
+              sep = "\t",
+              quote = F,
+              row.names = F)
+  } else {
+  sampleData <- read.table(SampleDataFile,
+                           sep = "\t",
+                           stringsAsFactors = FALSE,
+                           header = TRUE,
+                           quote = "\"",
+                           row.names = 1,
+                           check.names = FALSE)
+  multiQCFile <- file.path(paths$qc, "MultiQC_Report_data.zip")
+  multiqc_general_stats <- read.table(unz(multiQCFile, 'multiqc_general_stats.txt'),
+                                      header = TRUE, sep = "\t")
+  mu <- data.frame(Sample = multiqc_general_stats$Sample,
+                   FMR = multiqc_general_stats$STAR_mqc.generalstats.star.uniquely_mapped_percent/100)
+  row.names(mu) <- mu[,1]
+  }
+
 
 # B. Tab delimited sample information file with at least 2 columns:
 #    1. sample names identical to the column names of sampleData

--- a/scripts/temposeq/temposeq_quantification.R
+++ b/scripts/temposeq/temposeq_quantification.R
@@ -38,7 +38,7 @@ cnt <- qCount(proj2, txStart, clObj = cl)
 cnmat           <- as.data.frame(cnt, header=TRUE)
 #colnames(cnmat) <- gsub("fastqs/", "", colnames(cnmat))
 cnmat$width     <- NULL
-write.table(cnmat, count_table_file, sep='\t', quote=F, row.names=F)
+write.table(cnmat, count_table_file, sep='\t', quote=F, row.names=T)
 cat("Counts Table Completed\n")
 
 # Get Mapped/Unmapped Counts and Output
@@ -50,5 +50,5 @@ three       <- data.frame(two, check.names=FALSE)
 three$width <- NULL 
 ll          <- rbind(unmapped=unmapped, mapped=three)
 
-write.table(as.matrix(ll), mapped_unmapped_file, sep='\t', quote=F, row.names=F)
+write.table(as.matrix(ll), mapped_unmapped_file, sep='\t', quote=F, row.names=T)
 message("Mapped/Unmapped Table Completed\n")

--- a/scripts/temposeq/temposeq_quantification.R
+++ b/scripts/temposeq/temposeq_quantification.R
@@ -7,6 +7,9 @@ genome <- args[2]
 annotfile <- args[3]
 count_table_file <- args[4]
 mapped_unmapped_file <- args[5]
+num_threads   <- as.numeric(args[6])
+
+cl <- makeCluster(num_threads)
 
 # set up cache dir in tempdir
 cache_dir <- paste0(tempdir(),"/proba")
@@ -29,7 +32,7 @@ library(GenomicFeatures)
 txStart <- import.gff(annotfile, format="gtf")
 names(txStart) <- txStart@seqnames
 
-cnt <- qCount(proj2, txStart)
+cnt <- qCount(proj2, txStart, clObj = cl)
 
 # Make dataframe as count table
 cnmat           <- as.data.frame(cnt, header=TRUE)

--- a/scripts/temposeq/temposeq_quantification.R
+++ b/scripts/temposeq/temposeq_quantification.R
@@ -1,4 +1,8 @@
 #!/usr/bin/env Rscript
+library(parallel)
+library(QuasR)
+library(rtracklayer)
+library(GenomicFeatures)
 
 args = commandArgs(trailingOnly=TRUE)
 
@@ -15,19 +19,11 @@ cl <- makeCluster(num_threads)
 cache_dir <- paste0(tempdir(),"/proba")
 dir.create(cache_dir)
 
-
-# Import the QuasR library
-library(QuasR)
-
 message("Running qAlign function...")
 proj2 <- qAlign(samplefile,
                 genome,
                 paired="no",
                 cacheDir=cache_dir)
-
-message("Loading rtracklayer and GenomicFeatures...")
-library(rtracklayer)
-library(GenomicFeatures)
 
 txStart <- import.gff(annotfile, format="gtf")
 names(txStart) <- txStart@seqnames
@@ -36,7 +32,6 @@ cnt <- qCount(proj2, txStart, clObj = cl)
 
 # Make dataframe as count table
 cnmat           <- as.data.frame(cnt, header=TRUE)
-#colnames(cnmat) <- gsub("fastqs/", "", colnames(cnmat))
 cnmat$width     <- NULL
 write.table(cnmat, count_table_file, sep='\t', quote=F, row.names=T)
 cat("Counts Table Completed\n")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -200,7 +200,7 @@ rule STAR_make_index:
     shell:
         '''
 		STAR \
-        --runMode genomeGenerate \
+    --runMode genomeGenerate \
 		--genomeDir {params.index_dir} \
 		--genomeFastaFiles {input.genome} \
 		--sjdbGTFfile {params.annotations} \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -310,6 +310,7 @@ rule STAR_unload:
     run:
         shell("STAR --genomeLoad Remove --genomeDir {params.genome_dir}")
         shell("rm genome.loaded")
+        shell("rm Log.progress.out Log.final.out Log.out SJ.out.tab Aligned.out.sam")
 
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -356,14 +356,23 @@ if common_config["platform"] =="TempO-Seq":
             samplefile = processed_dir / "samplefile.txt"
         params:
             annotfile = str(genome_dir / pipeline_config["annotation_filename"]),
+            threads = pipeline_config["threads"],
             genome = str(genome_dir / pipeline_config["genome_filename"]),
+        threads: pipeline_config["threads"],
         output:
             count_table = processed_dir / "count_table.tsv",
             mapped_unmapped = processed_dir / "mapped_unmapped.tsv",
         benchmark: log_dir / "benchmark.quantification.txt"
         shell:
             '''
-            Rscript {temposeq_quantification_script} {input.samplefile} {params.genome} {params.annotfile} {output.count_table} {output.mapped_unmapped}
+            Rscript \
+            {temposeq_quantification_script} \
+            {input.samplefile} \
+            {params.genome} \
+            {params.annotfile} \
+            {output.count_table} \
+            {output.mapped_unmapped} \
+            {params.threads}
             '''
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -69,6 +69,8 @@ rule all:
         processed_dir / "count_table.tsv",
         "genome.removed",
     benchmark: log_dir / "benchmark.all.txt"
+    run:
+      shell("rm genome.removed")
 
 ##################################
 ### Trimming raw reads : Fastp ###

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,7 +27,6 @@ metadata_file = metadata_dir / "metadata.txt" # should aready exist
 #TODO set up a check to make sure this stuff exists
 
 if common_config["platform"] =="TempO-Seq":
-    temposeq_script = main_dir / "scripts/temposeq/TempO-SeqR_v3.1.R"
     temposeq_quantification_script = main_dir / "scripts/temposeq/temposeq_quantification.R"
 sample_id_col = pipeline_config["sample_id"]
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -80,7 +80,7 @@ if common_config["platform"] =="TempO-Seq":
 else:
     length_required_fastp = 36
     trim_tail1_fastp = 0
-
+fastp_threads = 2
 
 rule fastp_se:
     input:
@@ -98,9 +98,9 @@ rule fastp_se:
         right_quality = 15,
         length_required = length_required_fastp,
         trim_tail1 = trim_tail1_fastp,
-        threads = pipeline_config["threads"],
+        threads = fastp_threads,
     benchmark: log_dir / "benchmark.{sample}.fastp_se.txt"
-    threads: pipeline_config["threads"],
+    threads: fastp_threads,
     shell:
         '''
         fastp \
@@ -141,9 +141,9 @@ rule fastp_pe:
         right_size = 4,
         right_quality = 15,
         length_required = length_required_fastp,
-        threads = pipeline_config["threads"],
+        threads = fastp_threads,
     benchmark: log_dir / "benchmark.{sample}.fastp_pe.txt"
-    threads: pipeline_config["threads"],
+    threads: fastp_threads,
     shell:
         '''
         fastp \
@@ -180,7 +180,7 @@ else:
     STAR_insertion_deletion_penalty = -2 # STAR defaults
     STAR_multimap_nmax = 20
     STAR_mismatch_nmax = 999
-
+star_threads = 2
 
 # this rule is only used in RNA-seq jobs (not temposeq)
 rule STAR_make_index:
@@ -190,13 +190,13 @@ rule STAR_make_index:
         index_dir = genome_dir / "STAR_index",
         annotations = genome_dir / pipeline_config["annotation_filename"],
         overhang = 100,
-        threads = pipeline_config["threads"],
+        threads = workflow.cores,
         suffix_array_sparsity = 2, # bigger for smaller (RAM), slower indexing
         genomeChrBinNbits = 12, # might need to mess with this for different genomes
     output:
         directory(genome_dir / "STAR_index"),
     benchmark: log_dir / "benchmark.STAR_make_index.txt"
-    threads: pipeline_config["threads"],
+    threads: workflow.cores,
     shell:
         '''
 		STAR \
@@ -245,10 +245,10 @@ if pipeline_config["mode"] == "se":
             multimap_nmax = STAR_multimap_nmax,
             mismatch_nmax = STAR_mismatch_nmax,
             annotations = genome_dir / pipeline_config["annotation_filename"],
-            threads = pipeline_config["threads"],
+            threads = star_threads,
             bam_prefix = lambda wildcards : align_dir / "{}.".format(wildcards.sample),
         benchmark: log_dir / "benchmark.{sample}.STAR_pe.txt"
-        threads: pipeline_config["threads"],
+        threads: star_threads,
         shell:
             '''
             STAR \
@@ -280,12 +280,12 @@ if pipeline_config["mode"] == "pe":
         params:
             index = STAR_index,
             annotations = genome_dir / pipeline_config["annotation_filename"],
-            threads = copipeline_configfig["threads"],
+            threads = star_threads,
             bam_prefix = lambda wildcards : align_dir / "{}.".format(wildcards.sample),
         resources:
             load=100
         benchmark: log_dir / "benchmark.{sample}.STAR_se.txt"
-        threads: pipeline_config["threads"],
+        threads: star_threads,
         shell:
             '''
             STAR \
@@ -356,9 +356,9 @@ if common_config["platform"] =="TempO-Seq":
             samplefile = processed_dir / "samplefile.txt"
         params:
             annotfile = str(genome_dir / pipeline_config["annotation_filename"]),
-            threads = pipeline_config["threads"],
+            threads = workflow.cores,
             genome = str(genome_dir / pipeline_config["genome_filename"]),
-        threads: pipeline_config["threads"],
+        threads: workflow.cores,
         output:
             count_table = processed_dir / "count_table.tsv",
             mapped_unmapped = processed_dir / "mapped_unmapped.tsv",
@@ -407,11 +407,11 @@ if common_config["platform"] =="RNA-Seq":
                 isoforms = quant_dir / "{sample}.isoforms.results",
                 genes = quant_dir / "{sample}.genes.results",
             params:
-                threads = pipeline_config["threads"],
+                threads = workflow.cores,
                 output_prefix =  lambda wildcards : quant_dir / "{}".format(wildcards.sample),
                 index_name = pipeline_config["genome_name"],
             benchmark: log_dir / "benchmark.{sample}.RSEM_pe.txt"
-            threads: pipeline_config["threads"],
+            threads: workflow.cores,
             shell:
                 '''
                 rsem-calculate-expression \
@@ -432,11 +432,11 @@ if common_config["platform"] =="RNA-Seq":
                 isoforms = quant_dir / "{sample}.isoforms.results",
                 genes = quant_dir / "{sample}.genes.results",
             params:
-                threads = pipeline_config["threads"],
+                threads = workflow.cores,
                 output_prefix =  lambda wildcards : quant_dir / "{}".format(wildcards.sample),
                 index_name = pipeline_config["genome_name"],
             benchmark: log_dir / "benchmark.{sample}.RSEM_se.txt"
-            threads: pipeline_config["threads"]
+            threads: workflow.cores
             shell:
                 '''
                 rsem-calculate-expression \


### PR DESCRIPTION
* Multithreading improvements
* Change over all files to TSV, removing need for sampledata_sep
* Several parameters from the config had accidentally been removed from Rmd files, added back in this PR
* Got tired of being asked about read counts - made some boxplots and table showing summary stats (also mostly available in MultiQC report, but the Study wide QC now reports mean and median values for the study for read #, aligned %, etc.).