### PR TITLE
size / warnings for by gene plots

### DIFF
--- a/Rmd/DESeq2_report_new.Rmd
+++ b/Rmd/DESeq2_report_new.Rmd
@@ -252,8 +252,7 @@ This section contains plots showing the normalized counts per sample for each gr
 
 numResults <- params$nBestFeatures
 
-allResultsOrdered_logFC_filter <- dplyr::filter(allResults, abs(linearFoldChange) > params$linear_fc_filter) %>%
-  arrange(-abs(linearFoldChange))
+allResultsOrdered_logFC_filter <- significantResults %>% arrange(-abs(linearFoldChange))
 
 
 allResultsOrdered_logFC_filter %>%
@@ -278,7 +277,6 @@ allResultsOrdered_logFC_filter %>%
              size = 1) +
   theme_bw() +
   ggtitle(paste0("Top ",numResults," genes by fold change grouped by treatment"))
-
 
 ```
 

--- a/Rmd/DESeq2_report_new.Rmd
+++ b/Rmd/DESeq2_report_new.Rmd
@@ -284,7 +284,7 @@ allResultsOrdered_logFC_filter %>%
 
 The Y axis is on the log10 scale and the feature name is shown in the title of each plot.
 
-```{r genelevel_plots, results='asis', message = FALSE, fig.width = 10, fig.height = 10}
+```{r genelevel_plots, results='asis', message = FALSE, fig.width = 5, fig.height = 5}
 
 nBestFeatures <- params$nBestFeatures
 

--- a/scripts/DESeq_functions.R
+++ b/scripts/DESeq_functions.R
@@ -113,6 +113,7 @@ get_DESeq_results <- function(dds, DESeqDesign, contrasts, design, params, curre
                                alpha = params$alpha,
                                pAdjustMethod = 'fdr',
                                cooksCutoff = params$cooks) # If Cooks cutoff disabled - manually inspect.
+
         res <- lfcShrink(dds,
                          contrast = currentContrast,
                          res = res,
@@ -176,7 +177,7 @@ get_DESeq_results <- function(dds, DESeqDesign, contrasts, design, params, curre
         message(paste0("Filtering by linear fold-change: linear FC needs to be above ", params$linear_fc_filter))
         
         allCounts_all_filters <- res[rowSums(Filter) == 3 ,]
-        DECounts_real <- DEsamples[rowSums(Filter) == 3 & abs(DEsamples$log2FoldChange) > log2(params$linear_fc_filter) ,]
+        DECounts_real <- DEsamples[rowSums(Filter) == 3 & !is.na(DEsamples$padj) &  abs(DEsamples$log2FoldChange) > log2(params$linear_fc_filter) ,]
         DECounts_no_quant <- DEsamples[Filter[, 2] == 0 ,] # save these to output later 
         DECounts_spike <- DEsamples[Filter[, 3] == 0 ,] # save these to output later
         #TODO: output quantile rule failing and spike failing genes


### PR DESCRIPTION
fixes #85

Wasn't using the pre-filtered `significantResults` properly, so I fixed that and shrunk the plots so they're a little prettier.