### PR TITLE
Clean up of deseq formula determination

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -59,6 +59,7 @@ DESeq2:
   strict_contrasts: FALSE         # Use BOTH columns (exp, cont) of contrasts file to limit what is included in the report
   exclude_samples: null      # Optionally, a vector of sample names to exclude from the analysis
   exclude_groups: null       # Optionally, a vector of groups to exclude from the analysis. By default this is assumed to be in the column specified by params$design.
+  exclude_groups_column: null       # Optionally, specify a different column for excluding groups.
   include_only_column:  null # Restrict analysis to group(s) in the column listed here based on params$include_only_group.
   include_only_group:  null  # Restrict analysis to this/these group(s) within the column listed in params$include_only_column
   cpus: 41                       # Set to a lower number (e.g., 2 to 4) if you aren't working in a server environment

--- a/scripts/data_functions.R
+++ b/scripts/data_functions.R
@@ -12,25 +12,11 @@ filter_metadata <- function(exp_metadata, params, design){
     if (any(!is.na(params$exclude_groups))) {
         exp_metadata <- exp_metadata %>%
             dplyr::filter(!(!!sym(params$exclude_groups_column)) %in% params$exclude_groups)
-        contrasts_to_filter <- exp_metadata %>% 
-            dplyr::filter(!(!!sym(params$exclude_groups_column)) %in% params$exclude_groups) %>%
-            pull(design) %>% 
-            unique()
-        contrasts <- contrasts %>%
-            dplyr::filter(V1 %in% contrasts_to_filter)
-        if (params$strict_contrasts == T) {
-            contrasts <- contrasts %>%
-                dplyr::filter(V2 %in% contrasts_to_filter)
         }
     }
     if (!is.na(params$include_only_column) & !is.na(params$include_only_group)) {
         exp_metadata <- exp_metadata %>%
             dplyr::filter((!!sym(params$include_only_column)) %in% params$include_only_group)
-        limit_contrasts <- exp_metadata %>%
-            pull(!!sym(design)) %>%
-            unique() %>%
-            as.character()
-        contrasts <- contrasts %>% dplyr::filter(V1 %in% limit_contrasts)
     }
     return(exp_metadata)
 }
@@ -139,5 +125,4 @@ subset_results <- function(res, exp_metadata){
   exp_metadata_sorted <- exp_metadata[exp_metadata$original_names %in% colnames(count_data),]
   res_subset <- res[,exp_metadata_sorted$original_names]
   return(res_subset)
-  
 }

--- a/scripts/data_functions.R
+++ b/scripts/data_functions.R
@@ -7,11 +7,13 @@ filter_metadata <- function(exp_metadata, params, design){
             dplyr::filter(!original_names %in% params$exclude_samples)
     }
     # exclude groups
+    # If we haven't set exclude_groups_column, use the main params$design and assume they mean experimental groups from that
+    if (is.na(params$exclude_groups_column)) {params$exclude_groups_column = params$design}
     if (any(!is.na(params$exclude_groups))) {
         exp_metadata <- exp_metadata %>%
-            dplyr::filter(!(!!sym(design)) %in% params$exclude_groups)
+            dplyr::filter(!(!!sym(params$exclude_groups_column)) %in% params$exclude_groups)
         contrasts_to_filter <- exp_metadata %>% 
-            dplyr::filter(!(!!sym(design)) %in% params$exclude_groups) %>%
+            dplyr::filter(!(!!sym(params$exclude_groups_column)) %in% params$exclude_groups) %>%
             pull(design) %>% 
             unique()
         contrasts <- contrasts %>%


### PR DESCRIPTION
This PR will try to simplify how we run DESeq2 in terms of getting parameters from a configuration to the DESeq object.

Primarily, we will assume that users have a single column in the metadata that represents all the conditions for statistical testing. This column is the one that will be searched when looking for contrasts. This is how we already do most experiments and is the simplest way to accommodate user input.

The second important consideration is that of batch effects. In some cases, batch effect can be used in the DESeq formula.