### PR TITLE
Add zero counts heatmap + GC content plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Omics Data Analysis Frameworks for Regulatory application (R-ODAF) 
 
 | Issues | Pull Requests | Repository Size |  Languages | License |  Tests | 

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -277,6 +277,34 @@ stat_metrics %>%
 
 ```
 
+## Zero count heatmap
+
+```{r zero-heatmap, fig.width = 11, fig.height = 10}
+
+
+if(nrow(count_data) > 3000){
+  count_data_random <- df[sample(nrow(count_data), 2500), ]
+  count_data_is0 <- ((count_data_random==0)*1)
+} else{
+  count_data_is0 <- ((count_data==0)*1)
+}
+
+
+
+annotation_col <- exp_metadata %>%
+  dplyr::select(c(as.vector(unlist(params$exp_groups)),"sample_ID")) %>%
+  column_to_rownames("sample_ID")
+
+pheatmap(count_data_is0,
+         color = c("white", "black"),
+         annotation_col = annotation_col,
+         treeheight_col = 30,
+         cluster_rows=F,
+         show_rownames=F,
+         legend=T)
+
+```
+
 # Sample Filtering Code
 
 ## Samples Removed Manually
@@ -1252,6 +1280,7 @@ CairoPDF(file = file.path(paths$details, "dendrogram_postfiltering_all.pdf"),
 
 dendro_after_all_samples <- 1 - cor(as.matrix(cpm %>% dplyr::select(-all_of(outliers))),
                                   method = "spearman")
+
 dendro_after_all_samples <- sort_hclust(hclust(as.dist(dendro_after_all_samples), method = "average"))
 
 dendro_after_all_samples <- as.dendrogram(dendro_after_all_samples)

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -29,6 +29,8 @@ params:
   write_additional_output: TRUE # export BMD, biomarker, and biosets output? facet variable should contain chemical and timepoint information
   celltype: "Some cells" # only required for biosets output. Cell type or species used
   units: "uM" # only required for biosets output. Units of dose
+  biospyder_dbs: "~/shared/dbs/biospyder/"
+  biospyder_manifest_file:  "Human_S1500_1.2_standardized.csv"
 title: "`r paste('Study-wide sample quality control:', gsub(pattern = '_', replacement = ' ', x = params$project_title))`"
 subtitle: "`r paste(params$platform)`"
 output:
@@ -250,6 +252,36 @@ if (file.exists(remove_file)) {
 }
 ```
 
+
+```{r calculate-gc, eval=params$platform == "TempO-Seq"}
+
+
+calculate_gc <- function(seq) {
+  n_gc <- stringr::str_count(seq, "G")
+  n_c <- stringr::str_count(seq, "C")
+  pct_gc <- ((n_gc + n_c)/stringr::str_length(seq))
+  return(pct_gc)
+}
+
+# load manifest
+manifest <- read.csv(paste(params$biospyder_dbs, params$biospyder_manifest_file, sep="/"))
+# Calculate the GC content for each probe, add this value as a column
+manifest <- manifest %>% mutate(gc_content=calculate_gc(Probe_Sequence))
+
+count_data_gc <- dplyr::left_join(tibble::rownames_to_column(count_data),
+                                  manifest,
+                                  by = c("rowname" = "Probe_Name")) %>%
+  tidyr::pivot_longer(all_of(c(exp_metadata$original_names)),
+                      names_to = "sample", values_to = "count") %>%
+  
+  dplyr::mutate(GC_corrected_count = count/gc_content)
+
+
+
+
+```
+
+
 # Summary Statistics
 
 Below, you will find plots and a table showing the distribution of read metrics (quality, GC content, aligned reads, etc.).
@@ -276,6 +308,38 @@ stat_metrics %>%
 
 
 ```
+
+## GC content
+
+Summary of GC content of probes (TempO-Seq only)
+
+```{r plot-gc, eval=params$platform == "TempO-Seq"}
+
+ggplot(count_data_gc,aes(x=GC_corrected_count,colour=sample)) +
+  geom_density() +
+  scale_x_log10()
+
+gc_summary <- count_data_gc %>%
+  group_by(sample) %>%
+  summarise(median_gc = median(GC_corrected_count), mean_gc = mean(GC_corrected_count))
+
+gc_summary_long <- gc_summary %>%
+  pivot_longer(cols=c("mean_gc","median_gc"))
+
+ggplot(gc_summary_long,
+       aes(x=name, y=value)) +
+  geom_jitter(alpha = 0.1) +
+  geom_violin(fill = "transparent") +
+  facet_wrap(name~., scales = "free")
+
+gc_summary %>%
+  kable(caption = "Summary GC statistics") %>%
+  kable_styling(bootstrap_options = "striped", full_width = F, position = "left") %>%
+  scroll_box(width = "100%", height = "480px")
+
+
+```
+
 
 ## Zero count heatmap
 

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -343,6 +343,8 @@ gc_summary %>%
 
 ## Zero count heatmap
 
+Heatmap showing presence of zeroes (black) in the data.
+
 ```{r zero-heatmap, fig.width = 11, fig.height = 10}
 
 
@@ -363,9 +365,9 @@ pheatmap(count_data_is0,
          color = c("white", "black"),
          annotation_col = annotation_col,
          treeheight_col = 30,
-         cluster_rows=F,
+         treeheight_row = 0,
          show_rownames=F,
-         legend=T)
+         legend=F)
 
 ```
 

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -12,6 +12,11 @@ common:
   write_additional_output: FALSE # export BMD, biomarker, and biosets output? facet variable should contain chemical and timepoint information
   celltype: "MCF7 cells" # only required for biosets output. Cell type or species used
   units: "uM" # only required for biosets output. Units of dose
+  biospyder_dbs: "~/shared/dbs/biospyder/"
+  biospyder_manifest_file:  "181019_Human_S1500_Surrogate_1.2_Manifest.txt"
+  # "191113_Human_S1500_Surrogate_2.0_Manifest.csv"
+  # "181019_Human_S1500_Surrogate_1.2_Manifest.txt"
+  # "191004_Human_Whole_Transcriptome_2.0_Manifest.txt"
 
 ###### Alignment and processing pipeline parameters
 
@@ -64,11 +69,6 @@ DESeq2:
   cpus: 41                       # Set to a lower number (e.g., 2 to 4) if you aren't working in a server environment
   run_pathway_analysis: TRUE     # Optionally disable pathway analysis if not available for your organism
   wikipathways_directory: "~/shared/dbs/wikipathways"
-  biospyder_dbs: "~/shared/dbs/biospyder/"
-  biospyder_manifest_file:  "181019_Human_S1500_Surrogate_1.2_Manifest.txt"
-  # "191113_Human_S1500_Surrogate_2.0_Manifest.csv"
-  # "181019_Human_S1500_Surrogate_1.2_Manifest.txt"
-  # "191004_Human_Whole_Transcriptome_2.0_Manifest.txt"
   wikipathways_filename: "wikipathways-20210810-gmt-Homo_sapiens.gmt"
   # "wikipathways-20210810-gmt-Mus_musculus.gmt"
   # "wikipathways-20210810-gmt-Rattus_norvegicus.gmt"


### PR DESCRIPTION
1. Adds a heatmap to the QC report showing genes with zero counts. Could be illustrative in certain failure states.

For cases where there are >3000 genes (ie whole genome tempo-seq or RNA-seq), it plots a random 2500-gene subset.


2. Adds some plots summarizing the GC content of the data (for TempO-Seq only).