### PR TITLE
Fix clusterProfiler...

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,6 +59,7 @@ dependencies:
   #- r-cellWise
   # R Bioconductor
   - bioconductor-go.db #=3.13
+  - bioconductor-do.db # added because clusterProfiler suddenly stopped working
   - bioconductor-genomeinfodb #=1.28
   - bioconductor-genomeinfodbdata #=1.2.6
   - bioconductor-QuasR


### PR DESCRIPTION
Was getting error:
`first remote error: package or namespace load failed for 'clusterProfiler':
 package 'DO.db' was installed before R 4.0.0: please re-install it`

This should update that package alongside the rest. It is probably another un-specified dependency...