### PR TITLE
Update tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-20.04
             label: linux-64
             prefix: /usr/share/miniconda3/envs/base
-        r-version: ['4.1.1','4.3.1']
+        r-version: ['4.3.1']
         python-version: ['3.7']
         seq_type: ['temposeq'] # add later... , 'rnaseq']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Run tests only with latest version of R in base environment.
Note that the the R-ODAF_reports environment is activated whenever the workflow actually uses R, and the R version that gets installed there is currently R version 4.2.3.

This commit just prevents tests from being run twice unnecessarily.