### PR TITLE
pin python version 3.11 so that MultiQC v1.12 works

### DIFF
--- a/workflow/envs/preprocessing.yml
+++ b/workflow/envs/preprocessing.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - conda-forge::python=3.11
   - bioconda::rsem=1.3.3
   - bioconda::fastp=0.23.2
   - bioconda::star=2.7.10b


### PR DESCRIPTION
MultiQC v1.12 gets error if run in environment with python 3.12. Sticking with python v3.11 fixes this problem and doesn't cause others (for now).