### PR TITLE
Small fixes for faceting and formula_override problems

### DIFF
--- a/scripts/DESeq_functions.R
+++ b/scripts/DESeq_functions.R
@@ -1,6 +1,6 @@
 get_design <- function(design){
   #return(formula(paste0("~", paste0(c(design), collapse = " + "))))
-  if(!is.null(params$formula_override)) {
+  if(!is.na(params$formula_override)) {
     des <- formula(params$formula_override)
   } else { des <- formula(paste0("~", design)) }
   return(des)

--- a/scripts/data_functions.R
+++ b/scripts/data_functions.R
@@ -129,7 +129,9 @@ subset_metadata <- function(exp_metadata, design, contrasts, current_facet, curr
     if (params$strict_contrasts == T) {
         contrasts_subset <- contrasts_subset %>% dplyr::filter(V2 %in% contrasts_to_filter)
     }
-    exp_metadata_subset <- exp_metadata %>% dplyr::filter(!!sym(design) %in% (unlist(contrasts_subset) %>% unique()) )
+    exp_metadata_subset <- exp_metadata %>%
+      dplyr::filter(!!sym(design) %in% (unlist(contrasts_subset) %>% unique()) ) %>%
+      dplyr::filter(!!sym(current_facet) %in% current_filter)
     # relevel the design and interesting groups
     exp_metadata_subset[[design]] <- factor(exp_metadata_subset[[design]],
                                             levels = unique(unlist(contrasts_subset)),

--- a/scripts/render_DESeq2_report.parallel.R
+++ b/scripts/render_DESeq2_report.parallel.R
@@ -251,7 +251,9 @@ if (params$parallel){
 }
 
 # Add back after troubleshooting above code...
-source(here::here(file.path("scripts","summarize_across_facets.R")))
+if (!is.na(params$group_facet)) {
+  source(here::here(file.path("scripts","summarize_across_facets.R")))
+}
 
 # NOTE Manually clean up temporary files
 # This is required because of the clean_tmpfiles_mod() workaround!


### PR DESCRIPTION
These commits stop the analysis from breaking if 
- the formula_override config parameter is null
- facets parameter is null
- the facet value(s) aren't in the contrasts file (ex. facets are "A" and "B"; current code requires that the contrasts be something like:
A_10 A_0
