### PR TITLE
Add checks (intgroup_to_plot list, existence of ref files)

### DIFF
--- a/scripts/data_functions.R
+++ b/scripts/data_functions.R
@@ -104,9 +104,6 @@ check_data <- function(sd, des, con){
     stopifnot(all(des$original_names %in% colnames(sd)))
     # Sanity check: each column in the count data should have a corresponding sample (row) in the metadata
     stopifnot(all(colnames(sd) %in% des$original_names))
-    # Sanity check: config['group_facet'] not an element in config['intgroup_to_plot'] 
-    if(params$group_facet %in% params$intgroup_to_plot)
-        stop("The column for faceting should not be an element in your intgroup_to_plot list.")
     message("All OK 👍")
 }
 

--- a/scripts/data_functions.R
+++ b/scripts/data_functions.R
@@ -104,6 +104,9 @@ check_data <- function(sd, des, con){
     stopifnot(all(des$original_names %in% colnames(sd)))
     # Sanity check: each column in the count data should have a corresponding sample (row) in the metadata
     stopifnot(all(colnames(sd) %in% des$original_names))
+    # Sanity check: config['group_facet'] not an element in config['intgroup_to_plot'] 
+    if(params$group_facet %in% params$intgroup_to_plot)
+        stop("The column for faceting should not be an element in your intgroup_to_plot list.")
     message("All OK 👍")
 }
 

--- a/scripts/setup_functions.R
+++ b/scripts/setup_functions.R
@@ -19,6 +19,8 @@ check_required_params <- function(params){
       stop(paste0("Required param ",p," was NA. You should set that param to something in config.yaml."))
     } else if(is.null(params[p])){
       stop(paste0("Required param ",p," was null. This shouldn't happen, as you should be running 'replace_nulls_in_config"))
+    } else if(params$group_facet %in% params$intgroup_to_plot){
+      stop(paste0("The column for faceting (",params$group_facet,") should not be an element in your intgroup_to_plot list."))
     }
   }
 }

--- a/workflow/modules/1-define.smk
+++ b/workflow/modules/1-define.smk
@@ -13,6 +13,10 @@ common_config = config["common"]
 pipeline_config = config["pipeline"]
 deseq_config = config["DESeq2"]
 
+# Check that group_facet is not in intgroup_to_plot
+if deseq_config['group_facet'] in deseq_config['intgroup_to_plot']:
+    sys.exit(f"Error! 'group_facet' should not be in 'intgroup_to_plot' elements.")
+
 # Set up input directories
 main_dir = common_config["projectdir"]
 if main_dir is None:
@@ -39,6 +43,32 @@ sample_id_col = pipeline_config["sample_id"]
 
 SAMPLES = pd.read_table(metadata_file)[sample_id_col].tolist()
 print("samples: " + str(SAMPLES))
+
+
+# Check existence of reference files, break if not there
+genome_filename = pipeline_config["genome_filename"]
+annotation_filename = pipeline_config["annotation_filename"]
+
+genome_filepath = genome_dir / genome_filename
+annotation_filepath = genome_dir / annotation_filename
+
+check_ref_fasta = os.path.exists(genome_filepath)
+
+if check_ref_fasta == False:
+    sys.exit(f"Error! You are missing the expected reference genome file: {genome_filepath}")
+
+check_ref_genome = os.path.exists(annotation_filepath)
+
+if check_ref_genome == False:
+    sys.exit(f"Error! You are missing the expected reference annotation file: {annotation_filepath}")
+
+if common_config["platform"] =="TempO-Seq":
+    biospyder_filepath = common_config["biospyder_dbs"] + common_config["biospyder_manifest_file"]
+
+    check_manifest = os.path.exists(biospyder_filepath)
+
+    if check_manifest == False:
+        sys.exit(f"Error! You are missing the expected biospyder manifest file: {biospyder_filepath}")
 
 # Set up output directories
 

--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -148,7 +148,12 @@ properties:
         items:
           type: string
       intgroup_to_plot:
-        type: string
+        type: 
+          - string
+          - 'null'
+          - array
+        items:
+          type: string
       formula_override:
         type:
           - string


### PR DESCRIPTION
Now if anyone is foolish enough to include the faceting column in the intgroups_to_plot list in the config parameters, the analysis will be stopped and a helpful message will print so that troubleshooting takes less than 3 days.

There are checks in the snakemake code (module 1) and in the R code for anyone who runs with Rscript, independent of Snakemake.

Snakemake also checks whether the reference files specified in the config exist before starting the analysis.

Tests aren't running atm. I think we wore out all the github runners.