### PR TITLE
Update schema

### DIFF
--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -190,6 +190,7 @@ properties:
         items:
           type: string
       exclude_groups:
+        type:  
           - string
           - array
           - 'null'

--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -184,12 +184,17 @@ properties:
         type: boolean
       exclude_samples:
         type:
+          - string
           - array
           - 'null'
+        items:
+          type: string
       exclude_groups:
-        type:
+          - string
           - array
           - 'null'
+        items:
+          type: string
       include_only_column:
         type:
           - string

--- a/workflow/schema/metadata.schema.yaml
+++ b/workflow/schema/metadata.schema.yaml
@@ -29,6 +29,12 @@ properties:
     type: number
     minimum: 0
     description: Chemical dose given
+  I7_Index_ID:
+    type: string
+    description: The I7 index identifier. Column name is case-sensitive (otherwise Sample_QC will fail)
+  I5_Index_ID:
+    type: string
+    description: The I5 index identifier. Column name is case-sensitive (otherwise Sample_QC will fail)
   
 
 required:


### PR DESCRIPTION
Updated the config and metadata schema to fix a few problems. Case-sensitivity in Sample_QC.Rmd is a problem for the I7_Index_ID and I5_Index_ID columns (fails if they're I7_index_ID). Now that's caught before running. Exclusion lines in config can now be single items (strings) or a list of strings (so we can exclude multiple samples).