### PR TITLE
Print conda env contents during tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,15 @@ jobs:
         run: |
          conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | \
          sed s/\.yaml//) Rscript install.R
+      - name: Print contents of Conda environments
+        run: |
+          for env in .snakemake/conda/*; do
+            echo "Contents of $env:"
+            conda activate $env
+            conda list
+            conda deactivate
+          done
+        shell: bash -l {0}
       - name: Run workflow
         run: |
           snakemake --cores 8 --use-conda

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,13 +85,21 @@ jobs:
         run: |
          conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | \
          sed s/\.yaml//) Rscript install.R
+      - name: Print env names
+        run: |
+          for yaml in .snakemake/conda/*.yaml; do
+            echo "$yaml:"
+            head -n 1 "$yaml"
+          done
       - name: Print contents of Conda environments
         run: |
           for env in .snakemake/conda/*; do
-            echo "Contents of $env:"
-            conda activate $env
-            conda list
-            conda deactivate
+            if [ -d "$env" ]; then
+              echo "Contents of $env:"
+              conda activate $env
+              conda list
+              conda deactivate
+            fi
           done
         shell: bash -l {0}
       - name: Run workflow

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ inputs/reference/*
 *.gmt
 
 ## Outputs
-output/
+output*/
 count_table*.csv
 *metadata.QC_applied.txt
 /logs/


### PR DESCRIPTION
Add conda list commands so we can see the contents of environments installed during snakemake workflow during github actions.