### PR TITLE
print conda env packages during build

### DIFF
--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -39,6 +39,17 @@ RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda --conda-
 # Install extra dependency for reports
 RUN mamba run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R 
 
+# Print conda environment packages
+RUN /bin/bash -c "\
+  for env in .snakemake/conda/*; do \
+    if [ -d \"$env\" ]; then \
+      echo \"Contents of $env:\"; \
+      source activate $env; \
+      conda list; \
+      conda deactivate; \
+    fi; \
+  done"
+
 RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda \
       && df -h \
       && mkdir ./tests \


### PR DESCRIPTION
Added a conda list section to Dockerfile.new instead of Dockerfile (Dockerfile.new is used in build.yml). Reverted commits that edited Dockerfile. Curious to see what happens with the previous merges.