### PR TITLE
print conda env packages during build try3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          output: true
           tags: ghcr.io/r-odaf/r-odaf_health_canada:latest
           file: ./Dockerfile.new
           cache-from: type=registry,ref=ghcr.io/r-odaf/r-odaf_health_canada:cache

--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -50,8 +50,6 @@ RUN /bin/bash -c "\
     fi; \
   done" > /home/R-ODAF/conda_envs.txt
 
-RUN cat /home/R-ODAF/conda_envs.txt
-
 RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda \
       && df -h \
       && mkdir ./tests \


### PR DESCRIPTION
Now we're adding a Run command in Docker image just to print a file containing the conda envs package lists. I am not optimistic.