### PR TITLE
remove nonfunctional troubleshooting code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,17 +51,6 @@ RUN /bin/bash -c "snakemake --cores ${BUILD_CORES} --use-conda --conda-create-en
 # Install extra dependency for reports
 RUN /bin/bash -c "conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R"
 
-# Print conda environment packages
-RUN /bin/bash -c "\
-  for env in .snakemake/conda/*; do \
-    if [ -d \"$env\" ]; then \
-      echo \"Contents of $env:\"; \
-      source activate $env; \
-      conda list; \
-      conda deactivate; \
-    fi; \
-  done"
-
 # Change ownership of files
 USER root
 RUN chown -R R-ODAF:R-ODAF /home/R-ODAF

--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -43,17 +43,6 @@ RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda --conda-
 # Install extra dependency for reports
 RUN mamba run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R 
 
-# Print conda environment packages
-RUN /bin/bash -c "\
-  for env in .snakemake/conda/*; do \
-    if [ -d \"$env\" ]; then \
-      echo \"Contents of $env:\"; \
-      source activate $env; \
-      conda list; \
-      conda deactivate; \
-    fi; \
-  done" > /home/R-ODAF/conda_envs.txt
-
 RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda \
       && df -h \
       && mkdir ./tests \


### PR DESCRIPTION
Tidying up the docker files after my failed attempts at printing conda environments for troubleshooting purposes. Shouldn't change any functionality.