### PR TITLE
Qc group dendro cutoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,10 +48,15 @@
 *config.yaml
 inputs/reference/*
 *.gmt
+*.csv
+
+## Test data repo
+test-data/
 
 ## Outputs
 output*/
 count_table*.csv
+count_table*.tsv
 *metadata.QC_applied.txt
 /logs/
 *.pdf

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -430,6 +430,15 @@ plot(dendro_before_all_samples %>%
      horiz = F)
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
+
+# Repeat the plot so it appears in the HTML report
+plot(dendro_before_all_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+
 ```
 
 
@@ -499,6 +508,16 @@ if (length(dendro_before_tech_ctrls) > 2) {
   )
   abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
   invisible(dev.off())
+
+  # Repeat the plot so it appears in the HTML report
+  #par(cex = 0.4, mar = c(25, 4, 4, 2))
+  print(plot(dendro_before_tech_ctrls %>%
+               dendextend::set("labels", labels_to_use) %>%
+               dendextend::set("labels_cex", 0.3),
+             main = "log2 CPM",
+             horiz = F)
+  )
+  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 }
 
 ```
@@ -548,6 +567,16 @@ plot(dendro_before_all_exp_samples %>%
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
+# Repeat the plot so it appears in the HTML report
+
+#par(cex = 0.2, mar = c(25, 4, 4, 2))
+plot(dendro_before_all_exp_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+
 ############################################################################
 # Experimental Samples, Prefiltering, Colored by Dose
 ############################################################################
@@ -585,6 +614,15 @@ plot(dendro_before_all_exp_samples %>%
      horiz = F)
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
+
+# Repeat the plot so it appears in the HTML report
+#par(cex = 0.2, mar = c(25, 4, 4, 2))
+plot(dendro_before_all_exp_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 
 ```
 
@@ -1421,6 +1459,14 @@ plot(dendro_after_all_samples %>%
      horiz = F)
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
+
+# Repeat plot so it appears in the HTML report
+plot(dendro_after_all_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 ```
 
 ### Dendrogram, technical control samples, postfiltering
@@ -1463,6 +1509,14 @@ if (length(dendro_after_tech_ctrls) > 2) {
        horiz = F)
   abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
   invisible(dev.off())
+
+  # Repeat plot so it appears in the HTML report
+  plot(dendro_after_tech_ctrls %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+       main = "log2 CPM",
+       horiz = F)
+  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 }
 ```
 
@@ -1508,6 +1562,15 @@ plot(dendro_after_all_exp_samples %>%
      horiz = F)
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
+
+# Repeat the plot so it appears in the HTML report
+plot(dendro_after_all_exp_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+
 ```
 
 ### Dendrogram, experimental samples, postfiltering, colored by dose
@@ -1552,6 +1615,14 @@ plot(dendro_after_all_exp_samples %>%
      horiz = F)
 abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
+
+# Repeat the plot so it appears in the HTML report
+plot(dendro_after_all_exp_samples %>%
+       dendextend::set("labels", labels_to_use) %>%
+       dendextend::set("labels_cex", 0.3),
+     main = "log2 CPM",
+     horiz = F)
+abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
 ```
 
 

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -836,6 +836,10 @@ Click on the tabs below to see the robust PCA and Pearson correlations for all s
 ```{r group-correlation-setup}
 facets <- unique(exp_metadata_exp_samples[,params$treatment_var])
 cor_list <- list()
+
+facet_tree_cutoff <- 0.11 # Ideally this should be a config parameter!
+# Do we also want a separate config from params$treatment_var for the within-group tree cutoff?
+# Or to use the deseq_facet?
 ```
 
 ```{r, fig.width = 11, fig.height = 10, results='asis'}
@@ -852,7 +856,50 @@ for (i in seq_along(facets)) {
   correlations <- cor(cpm_subset, method = "pearson")
   correlation_df <- exp_metadata %>%
     filter(original_names %in% colnames(correlations))
+
+  ### Filtering by within-group correlations ###
+  dendro_facet <- 1 - cor(cpm_subset, method = clust_method)
+  dendro_facet <- sort_hclust(hclust(as.dist(dendro_facet), method = "average"))
+  dendro_facet <- as.dendrogram(dendro_facet)
+
+  facet_tree_groups <- cutree(dendro_facet, h = facet_tree_cutoff)
+  n_facet <- table(facet_tree_groups)
+  n_facet <- sort(n_facet, decreasing = T)
+
+  d_facet <- d %>% dplyr::filter(original_names %in% samples_in_facet)
+  if (!is.null(dim(n_facet))) {
+    n_facet <- n_facet[2:dim(n_facet)]
+
+    if (length(n_facet > 0)) {
+      flag_cluster_facet <- d_facet$original_names %in% names(facet_tree_groups[facet_tree_groups %in% as.integer(names(n_facet))])
+    }
+  } else {
+    flag_cluster_facet <- rep(FALSE, nrow(d_facet))
+  }
+
+  # Add clustering results column to dataframe
+  d_facet$flag_cluster_facet <- flag_cluster_facet
+
+  df_groupdendro_list[[i]] <- d_facet
+
+
+  # Output dendrograms per facet (currently it's by params$treatment_group!)
+  facet_dendro_filename = paste0("dendrogram_",facets[i],".pdf")
+  CairoPDF(file = file.path(paths$details, facet_dendro_filename),
+         width = 14,
+         height = 8.5,
+         family = "Courier")
   
+  par(cex = 0.75, mar = c(25, 4, 4, 2))
+  plot(dendro_facet %>%
+        dendextend::set("labels_cex", 1),
+      main = "log2 CPM",
+      horiz = F)
+  abline(h = facet_tree_cutoff, col = "red", lwd = 2)
+  invisible(dev.off())  
+
+
+### Make correlation robust PCA plots
   row.names(correlation_df) <- correlation_df$original_names
   correlation_df <- correlation_df[colnames(correlations),]
   correlation_df <- as.data.frame(correlation_df[unlist(exp_groups[[1]][1])])
@@ -873,6 +920,19 @@ for (i in seq_along(facets)) {
   cor_list[[i]] <- cor_distribution
   cat('  \n\n')
 }
+```
+
+
+```{r add_group_dendro_to_QCAC}
+df_groupdendro <- do.call(rbind, df_groupdendro_list)
+df_groupdendro <- df_groupdendro %>% 
+  dplyr::select(sample_ID, flag_cluster_facet) %>%
+  dplyr::rename(group_tree = flag_cluster_facet)
+df_groupdendro$group_tree <- ifelse(df_groupdendro$group_tree, "FAIL", "PASS")
+
+
+# Incorporate info into QAQC table
+QAQC <- merge(QAQC, df_groupdendro, by.x = "Sample", by.y = "sample_ID", all.x = TRUE)
 ```
 
 ## Distribution of correlations
@@ -1038,12 +1098,12 @@ QAQC_annotated$Any <- apply(QAQC_annotated,
 ```{r vtree}
 
 vtree(QAQC_annotated,
-      "Any dendrogram NMR FMR Ncov5 Nsig80 Gini", # Make "Any" first?
+      "Any dendrogram grouped-dendro NMR FMR Ncov5 Nsig80 Gini", # Make "Any" first?
       summary = "NMR_data \nAverage Reads Mapped\n%mean% %leafonly% ",
       pngknit = FALSE) # This is not ideal - but the tmp files didn't work when rendering externally.
 
 vtree(QAQC_annotated,
-      "dendrogram NMR FMR Ncov5 Nsig80 Gini",
+      "dendrogram grouped-dendro NMR FMR Ncov5 Nsig80 Gini",
       summary = "NMR_data \nAverage Reads Mapped\n%mean% %leafonly% ",
       pattern = T,
       pngknit = FALSE)
@@ -1270,7 +1330,7 @@ knitr::kable(QAQC_failed_kable,
 
 ```{r pass_fail_summary}
 QAQC_annotated %>%
-  dplyr::group_by(dendrogram, NMR, FMR, Ncov5, Nsig80, Gini, Any) %>%
+  dplyr::group_by(dendrogram, group_tree, NMR, FMR, Ncov5, Nsig80, Gini, Any) %>%
   tally() %>%
   knitr::kable(caption = "Summary of pass/fail results") %>%
   kable_styling(bootstrap_options = "striped", full_width = F, position = "left") %>%
@@ -1281,7 +1341,7 @@ QAQC_annotated %>%
 
 ```{r pass_fail_by_group}
 QAQC_annotated %>%
-  dplyr::group_by(dendrogram, NMR, FMR, Ncov5, Nsig80, Gini, Any, .data[[params$treatment_var]]) %>%
+  dplyr::group_by(dendrogram, group_tree, NMR, FMR, Ncov5, Nsig80, Gini, Any, .data[[params$treatment_var]]) %>%
   tally() %>%
   knitr::kable(caption = "Pass/fail results by group") %>%
   kable_styling(bootstrap_options = "striped", full_width = F, position = "left") %>%

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -6,6 +6,7 @@ params:
   project_description: null # description of project for report, optional
   clust_method: "spearman" # For clustering
   tree_height_cutoff: 0.1  # For clustering
+  treatmentvar_tree_height_cutoff: 0.2
   dendro_color_by: "group" # Specify how you would like to color the dendrograms
   nmr_threshold: 100000    # 10% of 1M reads for TempOSeq = 100,000; 10% of 10M reads for RNA-Seq = 1,000,000.
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
@@ -86,10 +87,6 @@ library(vtree) # Richard Webster and Nick Barrowman
 library(ggh4x)
 ```
 
-# print working directory for troubleshooting
-```{r}
-getwd()
-```
 
 ```{r params, include = FALSE, echo = FALSE, message = FALSE}
 exp_groups <- unname(params[["exp_groups"]]) # Include b/c of how things are addressed throughout.
@@ -837,13 +834,15 @@ Click on the tabs below to see the robust PCA and Pearson correlations for all s
 facets <- unique(exp_metadata_exp_samples[,params$treatment_var])
 cor_list <- list()
 
-facet_tree_cutoff <- 0.11 # Ideally this should be a config parameter!
-# Do we also want a separate config from params$treatment_var for the within-group tree cutoff?
+# Do we want a separate config param from params$treatment_var for the within-group tree cutoff?
 # Or to use the deseq_facet?
 ```
 
 ```{r, fig.width = 11, fig.height = 10, results='asis'}
 ### To view correlations for groups of interest...
+
+# Create list to populate with dataframes for each treatment_var group
+df_groupdendro_list <- list()
 
 for (i in seq_along(facets)) {
   cat("###", facets[i], "  \n\n")
@@ -858,45 +857,47 @@ for (i in seq_along(facets)) {
     filter(original_names %in% colnames(correlations))
 
   ### Filtering by within-group correlations ###
-  dendro_facet <- 1 - cor(cpm_subset, method = clust_method)
-  dendro_facet <- sort_hclust(hclust(as.dist(dendro_facet), method = "average"))
-  dendro_facet <- as.dendrogram(dendro_facet)
+  if(!is.na(params$treatmentvar_tree_height_cutoff)) {
+    dendro_facet <- 1 - cor(cpm_subset, method = params$clust_method)
+    dendro_facet <- sort_hclust(hclust(as.dist(dendro_facet), method = "average"))
+    dendro_facet <- as.dendrogram(dendro_facet)
 
-  facet_tree_groups <- cutree(dendro_facet, h = facet_tree_cutoff)
-  n_facet <- table(facet_tree_groups)
-  n_facet <- sort(n_facet, decreasing = T)
+    facet_tree_groups <- cutree(dendro_facet, h = params$treatmentvar_tree_height_cutoff)
+    n_facet <- table(facet_tree_groups)
+    n_facet <- sort(n_facet, decreasing = T)
 
-  d_facet <- d %>% dplyr::filter(original_names %in% samples_in_facet)
-  if (!is.null(dim(n_facet))) {
-    n_facet <- n_facet[2:dim(n_facet)]
+    d_facet <- d %>% dplyr::filter(original_names %in% samples_in_facet)
+    if (!is.null(dim(n_facet))) {
+      n_facet <- n_facet[2:dim(n_facet)]
 
-    if (length(n_facet > 0)) {
-      flag_cluster_facet <- d_facet$original_names %in% names(facet_tree_groups[facet_tree_groups %in% as.integer(names(n_facet))])
+      if (length(n_facet > 0)) {
+        flag_cluster_facet <- d_facet$original_names %in% names(facet_tree_groups[facet_tree_groups %in% as.integer(names(n_facet))])
+      }
+    } else {
+      flag_cluster_facet <- rep(FALSE, nrow(d_facet))
     }
-  } else {
-    flag_cluster_facet <- rep(FALSE, nrow(d_facet))
+
+    # Add clustering results column to dataframe
+    d_facet$flag_cluster_facet <- flag_cluster_facet
+
+    df_groupdendro_list[[i]] <- d_facet
+
+
+    # Output dendrograms per facet (currently it's by params$treatment_group!)
+    facet_dendro_filename = paste0("dendrogram_",facets[i],".pdf")
+    CairoPDF(file = file.path(paths$details, facet_dendro_filename),
+          width = 14,
+          height = 8.5,
+          family = "Courier")
+    
+    par(cex = 0.75, mar = c(25, 4, 4, 2))
+    plot(dendro_facet %>%
+          dendextend::set("labels_cex", 1),
+        main = "log2 CPM",
+        horiz = F)
+    abline(h = params$treatmentvar_tree_height_cutoff, col = "red", lwd = 2)
+    invisible(dev.off())  
   }
-
-  # Add clustering results column to dataframe
-  d_facet$flag_cluster_facet <- flag_cluster_facet
-
-  df_groupdendro_list[[i]] <- d_facet
-
-
-  # Output dendrograms per facet (currently it's by params$treatment_group!)
-  facet_dendro_filename = paste0("dendrogram_",facets[i],".pdf")
-  CairoPDF(file = file.path(paths$details, facet_dendro_filename),
-         width = 14,
-         height = 8.5,
-         family = "Courier")
-  
-  par(cex = 0.75, mar = c(25, 4, 4, 2))
-  plot(dendro_facet %>%
-        dendextend::set("labels_cex", 1),
-      main = "log2 CPM",
-      horiz = F)
-  abline(h = facet_tree_cutoff, col = "red", lwd = 2)
-  invisible(dev.off())  
 
 
 ### Make correlation robust PCA plots
@@ -924,11 +925,19 @@ for (i in seq_along(facets)) {
 
 
 ```{r add_group_dendro_to_QCAC}
-df_groupdendro <- do.call(rbind, df_groupdendro_list)
-df_groupdendro <- df_groupdendro %>% 
-  dplyr::select(sample_ID, flag_cluster_facet) %>%
-  dplyr::rename(group_tree = flag_cluster_facet)
-df_groupdendro$group_tree <- ifelse(df_groupdendro$group_tree, "FAIL", "PASS")
+if(!is.na(params$treatmentvar_tree_height_cutoff)) {
+  df_groupdendro <- do.call(rbind, df_groupdendro_list)
+  df_groupdendro <- df_groupdendro %>% 
+    dplyr::select(sample_ID, flag_cluster_facet) %>%
+    dplyr::rename(group_tree = flag_cluster_facet)
+  df_groupdendro$group_tree <- ifelse(df_groupdendro$group_tree, "FAIL", "PASS")
+} else {
+  # If no tree height cutoff is specified, all samples are considered to pass
+  df_groupdendro <- exp_metadata %>% 
+    dplyr::select(sample_ID) %>%
+    dplyr::mutate(group_tree = "PASS")
+}
+
 
 
 # Incorporate info into QAQC table
@@ -1098,12 +1107,12 @@ QAQC_annotated$Any <- apply(QAQC_annotated,
 ```{r vtree}
 
 vtree(QAQC_annotated,
-      "Any dendrogram grouped-dendro NMR FMR Ncov5 Nsig80 Gini", # Make "Any" first?
+      "Any dendrogram group_tree NMR FMR Ncov5 Nsig80 Gini", # Make "Any" first?
       summary = "NMR_data \nAverage Reads Mapped\n%mean% %leafonly% ",
       pngknit = FALSE) # This is not ideal - but the tmp files didn't work when rendering externally.
 
 vtree(QAQC_annotated,
-      "dendrogram grouped-dendro NMR FMR Ncov5 Nsig80 Gini",
+      "dendrogram group_tree NMR FMR Ncov5 Nsig80 Gini",
       summary = "NMR_data \nAverage Reads Mapped\n%mean% %leafonly% ",
       pattern = T,
       pngknit = FALSE)

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -408,20 +408,43 @@ dendro_before_all_samples <- 1 - cor(as.matrix(cpm), method = params$clust_metho
 dendro_before_all_samples <- sort_hclust(hclust(as.dist(dendro_before_all_samples), method = "average"))
 
 dendro_before_all_samples <- as.dendrogram(dendro_before_all_samples)
+# if (params$platform == "TempO-Seq") {
+#   colors_to_use <- as.numeric(as.factor(exp_metadata[, params$technical_control]))
+# } else{
+#   colors_to_use <- rep.int(0,96)
+# }
+# ordered_colors <- colors_to_use[order.dendrogram(dendro_before_all_samples)]
+# labels_colors(dendro_before_all_samples) <- ordered_colors
+
+# original_names <- exp_metadata[, "original_names"]
+# original_names <- original_names[order.dendrogram(dendro_before_all_samples)]
+
+# labels_to_use <- exp_metadata[, params$dendro_color_by]
+# labels_to_use <- labels_to_use[order.dendrogram(dendro_before_all_samples)]
+# labels_to_use <- paste(labels_to_use, original_names)
+
+prefilt_dend_names <- colnames(cpm)
+prefilt_dend_names <- prefilt_dend_names[order.dendrogram(dendro_before_all_samples)]
+
+# Match the order of cpm column names in exp_metadata
+exp_metadata_ordered <- exp_metadata[match(colnames(cpm), exp_metadata$original_names), ]
+
+# Create prefilt_dend_labels, order based on the dendrogram
+prefilt_dend_labels <- exp_metadata_ordered[, params$dendro_color_by]
+prefilt_dend_labels <- prefilt_dend_labels[order.dendrogram(dendro_before_all_samples)]
+
 if (params$platform == "TempO-Seq") {
-  colors_to_use <- as.numeric(as.factor(exp_metadata[, params$technical_control]))
+colors_to_use <- ifelse(exp_metadata_ordered$technical_control == TRUE, "red", "black")
 } else{
   colors_to_use <- rep.int(0,96)
 }
+
+# Order colors based on the dendrogram
 ordered_colors <- colors_to_use[order.dendrogram(dendro_before_all_samples)]
+
+# Assign colors to the dendrogram labels
 labels_colors(dendro_before_all_samples) <- ordered_colors
-
-original_names <- exp_metadata[, "original_names"]
-original_names <- original_names[order.dendrogram(dendro_before_all_samples)]
-
-labels_to_use <- exp_metadata[, params$dendro_color_by]
-labels_to_use <- labels_to_use[order.dendrogram(dendro_before_all_samples)]
-labels_to_use <- paste(labels_to_use, original_names)
+labels_to_use <- paste(prefilt_dend_labels, prefilt_dend_names)
 
 plot(dendro_before_all_samples %>%
        dendextend::set("labels", labels_to_use) %>%

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -5,8 +5,8 @@ params:
   project_name: "Your name here" 
   project_description: null # description of project for report, optional
   clust_method: "spearman" # For clustering
-  tree_height_cutoff: 0.1  # For clustering
-  treatmentvar_tree_height_cutoff: 0.2
+  studywide_tree_height_cutoff: 0.1  # For clustering
+  group_tree_height_cutoff: 0.2
   dendro_color_by: "group" # Specify how you would like to color the dendrograms
   nmr_threshold: 100000    # 10% of 1M reads for TempOSeq = 100,000; 10% of 10M reads for RNA-Seq = 1,000,000.
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
@@ -369,7 +369,7 @@ if (nrow(cytotoxic) >= 1) {
 
 ## Dendrogram and distance based filtering
 
-A tree height cutoff of `r params$tree_height_cutoff` is used to cut the tree and separate outliers.
+A tree height cutoff of `r params$studywide_tree_height_cutoff` is used to cut the tree and separate outliers.
 
 ### Dendrogram, all samples, prefiltering
 
@@ -428,7 +428,7 @@ plot(dendro_before_all_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat the plot so it appears in the HTML report
@@ -437,7 +437,7 @@ plot(dendro_before_all_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 
 ```
 
@@ -506,7 +506,7 @@ if (length(dendro_before_tech_ctrls) > 2) {
              main = "log2 CPM",
              horiz = F)
   )
-  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+  abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
   invisible(dev.off())
 
   # Repeat the plot so it appears in the HTML report
@@ -517,7 +517,7 @@ if (length(dendro_before_tech_ctrls) > 2) {
              main = "log2 CPM",
              horiz = F)
   )
-  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+  abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 }
 
 ```
@@ -564,7 +564,7 @@ plot(dendro_before_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat the plot so it appears in the HTML report
@@ -575,7 +575,7 @@ plot(dendro_before_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 
 ############################################################################
 # Experimental Samples, Prefiltering, Colored by Dose
@@ -612,7 +612,7 @@ plot(dendro_before_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat the plot so it appears in the HTML report
@@ -622,7 +622,7 @@ plot(dendro_before_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 
 ```
 
@@ -632,14 +632,14 @@ Click on the tabs below to view samples removed by each metric.
 
 ### Clustering Distance Cutoff
 
-A `r params$clust_method` distance of `r params$tree_height_cutoff` is used to cut the tree and separate outliers.
+A `r params$clust_method` distance of `r params$studywide_tree_height_cutoff` is used to cut the tree and separate outliers.
 
 ```{r filtering_dendrogram}
 ############################################################################
 # Filtering
 ############################################################################
 
-tree_groups <- cutree(dendro_before_all_samples, h = params$tree_height_cutoff)
+tree_groups <- cutree(dendro_before_all_samples, h = params$studywide_tree_height_cutoff)
 n <- table(tree_groups)
 n <- sort(n, decreasing = T)
 
@@ -895,12 +895,12 @@ for (i in seq_along(facets)) {
     filter(original_names %in% colnames(correlations))
 
   ### Filtering by within-group correlations ###
-  if(!is.na(params$treatmentvar_tree_height_cutoff)) {
+  if(!is.na(params$group_tree_height_cutoff)) {
     dendro_facet <- 1 - cor(cpm_subset, method = params$clust_method)
     dendro_facet <- sort_hclust(hclust(as.dist(dendro_facet), method = "average"))
     dendro_facet <- as.dendrogram(dendro_facet)
 
-    facet_tree_groups <- cutree(dendro_facet, h = params$treatmentvar_tree_height_cutoff)
+    facet_tree_groups <- cutree(dendro_facet, h = params$group_tree_height_cutoff)
     n_facet <- table(facet_tree_groups)
     n_facet <- sort(n_facet, decreasing = T)
 
@@ -933,7 +933,7 @@ for (i in seq_along(facets)) {
           dendextend::set("labels_cex", 1),
         main = "log2 CPM",
         horiz = F)
-    abline(h = params$treatmentvar_tree_height_cutoff, col = "red", lwd = 2)
+    abline(h = params$group_tree_height_cutoff, col = "red", lwd = 2)
     invisible(dev.off())  
   }
 
@@ -963,7 +963,7 @@ for (i in seq_along(facets)) {
 
 
 ```{r add_group_dendro_to_QCAC}
-if(!is.na(params$treatmentvar_tree_height_cutoff)) {
+if(!is.na(params$group_tree_height_cutoff)) {
   df_groupdendro <- do.call(rbind, df_groupdendro_list)
   df_groupdendro <- df_groupdendro %>% 
     dplyr::select(sample_ID, flag_cluster_facet) %>%
@@ -1457,7 +1457,7 @@ plot(dendro_after_all_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat plot so it appears in the HTML report
@@ -1466,7 +1466,7 @@ plot(dendro_after_all_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 ```
 
 ### Dendrogram, technical control samples, postfiltering
@@ -1507,7 +1507,7 @@ if (length(dendro_after_tech_ctrls) > 2) {
        dendextend::set("labels_cex", 0.3),
        main = "log2 CPM",
        horiz = F)
-  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+  abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
   invisible(dev.off())
 
   # Repeat plot so it appears in the HTML report
@@ -1516,7 +1516,7 @@ if (length(dendro_after_tech_ctrls) > 2) {
        dendextend::set("labels_cex", 0.3),
        main = "log2 CPM",
        horiz = F)
-  abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+  abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 }
 ```
 
@@ -1560,7 +1560,7 @@ plot(dendro_after_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat the plot so it appears in the HTML report
@@ -1569,7 +1569,7 @@ plot(dendro_after_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 
 ```
 
@@ -1613,7 +1613,7 @@ plot(dendro_after_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 invisible(dev.off())
 
 # Repeat the plot so it appears in the HTML report
@@ -1622,7 +1622,7 @@ plot(dendro_after_all_exp_samples %>%
        dendextend::set("labels_cex", 0.3),
      main = "log2 CPM",
      horiz = F)
-abline(h = params$tree_height_cutoff, col = "red", lwd = 2)
+abline(h = params$studywide_tree_height_cutoff, col = "red", lwd = 2)
 ```
 
 

--- a/inputs/config/config.default.yaml
+++ b/inputs/config/config.default.yaml
@@ -34,6 +34,7 @@ pipeline:
 QC:
   clust_method: "spearman" # For clustering
   tree_height_cutoff: 0.1  # For clustering
+  treatmentvar_tree_height_cutoff: null # cluster by treatment_var groups and remove samples branching above this height. Can be set to null to skip this QC step
   dendro_color_by: "group" # Specify how you would like to color the dendrograms
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
   gini_cutoff: 0.95

--- a/inputs/config/config.default.yaml
+++ b/inputs/config/config.default.yaml
@@ -33,8 +33,8 @@ pipeline:
 ###### QC parameters
 QC:
   clust_method: "spearman" # For clustering
-  tree_height_cutoff: 0.1  # For clustering
-  treatmentvar_tree_height_cutoff: null # cluster by treatment_var groups and remove samples branching above this height. Can be set to null to skip this QC step
+  studywide_tree_height_cutoff: 0.1  # For clustering
+  group_tree_height_cutoff: null # cluster by treatment_var groups and remove samples branching above this height. Can be set to null to skip this QC step
   dendro_color_by: "group" # Specify how you would like to color the dendrograms
   align_threshold: 0.5     # 50% alignment rate for TempO-Seq Experiments
   gini_cutoff: 0.95

--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -93,6 +93,10 @@ properties:
       tree_height_cutoff:
         type: number
         minimum: 0
+      treatmentvar_tree_height_cutoff:
+        type:
+          - number
+          - 'null'
       dendro_color_by:
         type: string
       align_threshold:

--- a/workflow/schema/config.schema.yaml
+++ b/workflow/schema/config.schema.yaml
@@ -90,10 +90,10 @@ properties:
     properties:
       clust_method:
         type: string
-      tree_height_cutoff:
+      studywide_tree_height_cutoff:
         type: number
         minimum: 0
-      treatmentvar_tree_height_cutoff:
+      group_tree_height_cutoff:
         type:
           - number
           - 'null'
@@ -124,7 +124,7 @@ properties:
         type: string
     required:
       - clust_method
-      - tree_height_cutoff
+      - studywide_tree_height_cutoff
       - dendro_color_by
       - align_threshold
       - gini_cutoff


### PR DESCRIPTION
Adds a quality control step, analogous to the current dendrogram tree height cutoff, but working with trees within each treatment_var group instead of the project as a whole. The config parameter for the within-group trees can be set to null to skip this step and run the QC as normal. 

This is helpful for projects where some treatment groups are quite different from the rest in the project, which would cause that group to be considered an outlier in the studywide-tree, even though it really is biologically distinct. In that case, the studywide-tree height cutoff can be loosened, and the group-tree threshold used to remove outliers instead.