### PR TITLE
Move qc'ed metadata output

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Generate md5sums
         run: |
           md5sum output/processed/count_table.tsv > checksum.count_table
-          md5sum inputs/metadata/metadata.QC_applied.txt > checksum.metadata.QC_applied
+          md5sum output/QC/metadata.QC_applied.txt > checksum.metadata.QC_applied
           md5sum output/QC/MultiQC_Report_data.zip > checksum.multiQC
           md5sum output/QC/details/QC_per_sample.txt > checksum.QC_per_sample
           md5sum output/analysis/analysis_default_????????-????/DEG_lists/BaP/*.txt > checksums.BaP_DEGs #wildcards for timestamped folder

--- a/R.ODAF.utils/R/get_metadata.R
+++ b/R.ODAF.utils/R/get_metadata.R
@@ -11,7 +11,7 @@
 get_metadata <- function(file_path = NULL, paths) {
   if (is.null(file_path)) {
     message("No file path provided for metadata. Using default path.")
-    file_path <- file.path(paths[["metadata"]], "metadata.QC_applied.txt")
+    file_path <- file.path(paths[["qc"]], "metadata.QC_applied.txt")
   }
   # Make sure file exists before attempting to read
   if (!file.exists(file_path)) {

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -1443,7 +1443,7 @@ write.table(QAQC_annotated,
             sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 write.table(metadata_outliers_removed,
-            file.path(paths$metadata, "metadata.QC_applied.txt"),
+            file.path(paths$qc, "metadata.QC_applied.txt"),
             sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 count_data_filtered <- count_data %>% dplyr::select(-all_of(outliers))

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -1036,7 +1036,6 @@ cor_plot <- ggplot(cor_distribution_all, aes(.data[[params$treatment_var]], mean
   geom_boxplot(outlier.shape = NA, outlier.color = NA) +
   geom_jitter(size = 0.5) +
   theme(axis.text = element_text(angle = 90))
-ggsave("File", device = "pdf")
 ggplotly(cor_plot)
 # Ok, there's a bug that prevents outliers from being hidden, but whatever.
 # https://github.com/plotly/plotly.R/issues/1114

--- a/scripts/render_DESeq2_report.parallel.R
+++ b/scripts/render_DESeq2_report.parallel.R
@@ -50,7 +50,7 @@ rm(data_env)
 gc()
 
 # Read in metadata
-exp_metadata <- R.ODAF.utils::get_metadata(file.path(paths$metadata, "metadata.QC_applied.txt"), paths)
+exp_metadata <- R.ODAF.utils::get_metadata(file.path(paths$qc, "metadata.QC_applied.txt"), paths)
 
 facets <- R.ODAF.utils::get_facets(exp_metadata, params)
 

--- a/scripts/run_DESeq2.R
+++ b/scripts/run_DESeq2.R
@@ -28,7 +28,7 @@ paths <- R.ODAF.utils::set_up_filepaths(params, results_location_arg)
 ##############################################################################################
 
 # Read in metadata
-exp_metadata <- R.ODAF.utils::get_metadata(file.path(paths$metadata, "metadata.QC_applied.txt"), paths)
+exp_metadata <- R.ODAF.utils::get_metadata(file.path(paths$qc, "metadata.QC_applied.txt"), paths)
 sample_count_metadata <- list()
 sample_count_metadata$samples_postQC <- nrow(exp_metadata)
 


### PR DESCRIPTION
Now metadata.QC_applied.txt goes in the output/QC folder instead of inputs/metadata. This cleans up the organization, as all files in inputs/ are those provided by the user before running the pipeline. It also prevents the file from being overwritten when multiple rounds of QC are done with different parameters, and makes it easier to associate a particular metadata.QC_applied.txt file with the round of QC that produced it.

Note that the truth checksum file in the test data repo was changed to reflect this, so branches without this merge will no longer pass tests.