### PR TITLE
hotfix check for deseq_facet in intgroup_to_plot caused error in unf…

### DIFF
--- a/workflow/modules/1-define.smk
+++ b/workflow/modules/1-define.smk
@@ -14,8 +14,9 @@ pipeline_config = config["pipeline"]
 deseq_config = config["DESeq2"]
 
 # Check that deseq_facet is not in intgroup_to_plot
-if deseq_config['deseq_facet'] in deseq_config['intgroup_to_plot']:
-    sys.exit(f"Error! 'deseq_facet' should not be in 'intgroup_to_plot' elements.")
+
+if deseq_config['deseq_facet'] is not None and deseq_config['deseq_facet'] in deseq_config['intgroup_to_plot']:
+    sys.exit(f"Error! The column used for 'deseq_facet' should not be in 'intgroup_to_plot' elements.")
 
 # Set up input directories
 main_dir = common_config["projectdir"]


### PR DESCRIPTION
Check for deseq_facet in intgroup_to_plot caused error in unfaceted runs (ie when deseq_facet was null). Now it only checks if deseq_facet is not null. 