### PR TITLE
Try miniforge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge
-            miniforge-version: latest
+            miniforge-version: 24.7.1-2
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Mambaforge
+            miniforge-variant: Miniforge
             miniforge-version: latest
             environment-file: workflow/envs/base.yml
             activate-environment: base

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Miniforge
-            miniforge-version: 24.9.0-0
+            miniforge-variant: Miniforge3
+            miniforge-version: 23.3.1-0
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge
-            miniforge-version: 24.7.1-2
+            miniforge-version: 24.9.0-0
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true


### PR DESCRIPTION
Mambaforge is being sunsetted, so we have to switch to miniforge3 for the github workflows. Not sure if this will fix the problems in build.yml as well.

https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/