### PR TITLE
Change github workfows from mambaforge to miniforge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and push a container to GHCR
 on:
   push:
     branches:
-      - include_r_pkg
+      - try_miniforge
       - main
 
 permissions:
@@ -37,7 +37,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          output: true
           tags: ghcr.io/r-odaf/r-odaf_health_canada:r-pkg-test
           file: ./Dockerfile
           cache-from: type=registry,ref=ghcr.io/r-odaf/r-odaf_health_canada:cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge
-            miniforge-version: latest
+            miniforge-version: 24.7.1-2
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Deactivate any active Conda environment
+        run: |
+          if [ -d "/home/runner/miniconda3" ]; then
+            source /home/runner/miniconda3/bin/activate
+            conda deactivate
+          fi
       - name: Remove existing Conda environment
         run: |
           if [ -d "/home/runner/miniconda3" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup Mambaforge
+      - name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge3
             miniforge-version: 23.3.1-0
             environment-file: workflow/envs/base.yml
-            activate-environment: not_base
+            activate-environment: rodaf_base
             use-mamba: true
             python-version: ${{ matrix.python-version }}
             mamba-version: "*"
@@ -63,7 +63,7 @@ jobs:
           conda config --show channels
           conda search r-matrixstats
       - name: Update environment
-        run: mamba env update -n not_base -f workflow/envs/base.yml
+        run: mamba env update -n rodaf_base -f workflow/envs/base.yml
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Check conda install
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Mambaforge
+            miniforge-variant: Miniforge
             miniforge-version: latest
             environment-file: workflow/envs/base.yml
             activate-environment: base

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Remove existing Conda environment
+        run: |
+          if [ -d "/home/runner/miniconda3" ]; then
+            sudo rm -rf /home/runner/miniconda3
+          fi
       - name: Install linux dependencies
         run: |
           sudo apt-get update
@@ -43,7 +48,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup Mambaforge
+      - name: Setup Miniforge3
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Miniforge
-            miniforge-version: 24.9.0-0
+            miniforge-variant: Miniforge3
+            miniforge-version: 23.3.1-0
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Remove existing Conda environment
         run: |
           if [ -d "/home/runner/miniconda3" ]; then
+            /home/runner/miniconda3/bin/conda env remove --name base --yes
             sudo rm -rf /home/runner/miniconda3
           fi
       - name: Install linux dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,10 +41,9 @@ jobs:
             source /home/runner/miniconda3/bin/activate
             conda deactivate
           fi
-      - name: Remove existing Conda environment
+      - name: Remove existing Conda installation
         run: |
           if [ -d "/home/runner/miniconda3" ]; then
-            /home/runner/miniconda3/bin/conda env remove --name base --yes
             sudo rm -rf /home/runner/miniconda3
           fi
       - name: Install linux dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,10 @@ jobs:
       #     path: ${{ matrix.prefix }}
       #     key: ${{ matrix.label }}-conda-${{ hashFiles('workflow/envs/base.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
       #   id: cache
+      - name: List available channels and packages
+        run: |
+          conda config --show channels
+          conda search r-matrixstats
       - name: Update environment
         run: mamba env update -n base -f workflow/envs/base.yml
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,5 @@
 # This workflow is used for testing whether the DEG list produced by the new code is identical to the expected result based on example data.
-
 name: Tests
-
 on:
   push:
     branches:
@@ -11,10 +9,8 @@ on:
     - cron: '0 0 1 * *'
 env:
   CACHE_NUMBER: 0
-
 permissions:
   contents: read
-
 jobs:
   tests:
     env:
@@ -32,20 +28,8 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-
     steps:
       - uses: actions/checkout@v3
-      - name: Deactivate any active Conda environment
-        run: |
-          if [ -d "/home/runner/miniconda3" ]; then
-            source /home/runner/miniconda3/bin/activate
-            conda deactivate
-          fi
-      - name: Remove existing Conda installation
-        run: |
-          if [ -d "/home/runner/miniconda3" ]; then
-            sudo rm -rf /home/runner/miniconda3
-          fi
       - name: Install linux dependencies
         run: |
           sudo apt-get update
@@ -54,13 +38,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Setup Miniforge3
+      - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge3
             miniforge-version: 23.3.1-0
             environment-file: workflow/envs/base.yml
-            activate-environment: base
+            activate-environment: not_base
             use-mamba: true
             python-version: ${{ matrix.python-version }}
             mamba-version: "*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           conda config --show channels
           conda search r-matrixstats
       - name: Update environment
-        run: mamba env update -n base -f workflow/envs/base.yml
+        run: mamba env update -n not_base -f workflow/envs/base.yml
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Check conda install
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Miniforge
-            miniforge-version: 24.7.1-2
+            miniforge-version: 24.9.0-0
             environment-file: workflow/envs/base.yml
             activate-environment: base
             use-mamba: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ USER R-ODAF
 RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda --conda-create-envs-only 
 
 # Install extra dependency for reports
-RUN mamba run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R 
+RUN conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R 
 
 RUN snakemake --cores ${BUILD_CORES} --software-deployment-method conda \
       && df -h \

--- a/workflow/envs/base.yml
+++ b/workflow/envs/base.yml
@@ -1,7 +1,7 @@
 # Using an environment name other than "base" is not recommended!
 # Read https://github.com/mamba-org/micromamba-docker#multiple-environments
 # if you must use a different environment name.
-name: not_base
+name: rodaf_base
 channels:
   - conda-forge
   - defaults

--- a/workflow/envs/base.yml
+++ b/workflow/envs/base.yml
@@ -1,7 +1,7 @@
 # Using an environment name other than "base" is not recommended!
 # Read https://github.com/mamba-org/micromamba-docker#multiple-environments
 # if you must use a different environment name.
-name: base
+name: not_base
 channels:
   - conda-forge
   - defaults

--- a/workflow/envs/reports.yml
+++ b/workflow/envs/reports.yml
@@ -50,7 +50,7 @@ dependencies:
   - conda-forge::r-ggupset=0.3.0 # required by enrichplot, but not in dependency list
   - conda-forge::r-crosstalk=1.2.0
   - conda-forge::r-ggh4x
-  # - conda-forge::r-matrixstats=1.1.0 #v1.2 breaks DESeq2_report_new.Rmd
+  - conda-forge::r-matrixstats=1.4.1 #v1.2 breaks DESeq2_report_new.Rmd
   - conda-forge::r-formattable=0.2.1
   # Install these via different mechanism.
   #- bioconda::r-crosstool

--- a/workflow/envs/reports.yml
+++ b/workflow/envs/reports.yml
@@ -50,7 +50,7 @@ dependencies:
   - conda-forge::r-ggupset=0.3.0 # required by enrichplot, but not in dependency list
   - conda-forge::r-crosstalk=1.2.0
   - conda-forge::r-ggh4x
-  - conda-forge::r-matrixstats=1.4.1 #v1.2 breaks DESeq2_report_new.Rmd
+  # - conda-forge::r-matrixstats=1.4.1 # If included, github test workflow fails
   - conda-forge::r-formattable=0.2.1
   # Install these via different mechanism.
   #- bioconda::r-crosstool

--- a/workflow/envs/reports.yml
+++ b/workflow/envs/reports.yml
@@ -50,7 +50,7 @@ dependencies:
   - conda-forge::r-ggupset=0.3.0 # required by enrichplot, but not in dependency list
   - conda-forge::r-crosstalk=1.2.0
   - conda-forge::r-ggh4x
-  - conda-forge::r-matrixstats=1.1.0 #v1.2 breaks DESeq2_report_new.Rmd
+  # - conda-forge::r-matrixstats=1.1.0 #v1.2 breaks DESeq2_report_new.Rmd
   - conda-forge::r-formattable=0.2.1
   # Install these via different mechanism.
   #- bioconda::r-crosstool


### PR DESCRIPTION
Mambaforge is being sunsetted, so test workflow file had to be updated to use miniforge. This caused tests to fail for other reasons, which have been resolved by:
- renaming environment specified in base.yml from base to rodaf_base
- unpinning r-matrixstats package
- replacing "mamba run" with "conda run" in docker file.

Hopefully with these changes, test and build workflows will continue working for a while!