### PR TITLE
Small updates during Hmec 2024

### DIFF
--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -1531,7 +1531,7 @@ If you set a group tree height cutoff in the config file, then any sample separa
 
 All dendrograms below are pre-filtering.
 
-```{r display-dendrograms, results='asis', echo=FALSE}
+```{r display-dendrograms, results='asis', echo=FALSE, fig.height=6}
 # Display the saved dendrograms from chunk "group-dendrograms"
 
 for (facet in names(dendrograms)) {
@@ -1539,7 +1539,7 @@ for (facet in names(dendrograms)) {
   dendro_facet <- dendrograms[[facet]]
 
   # Plot dendrogram
-  par(cex = 0.75, mar = c(25, 4, 4, 2))
+  par(cex = 0.75, mar = c(10, 4, 4, 2))
   plot(dendro_facet %>%
          dendextend::set("labels_cex", 1),
        main = "log2 CPM",

--- a/Rmd/Sample_QC.Rmd
+++ b/Rmd/Sample_QC.Rmd
@@ -369,9 +369,11 @@ stat_metrics %>%
 
 ```
 
-# PCA
+# PCA {.tabset}
 
-The PCA plot below shows the distribution of samples in the study. It shows  *experimental samples*, and does not include techical contral samples, reference RNA samples, or experimental samples which were manually removed. This plot shows the first two principal components that explain the variability in the data using the regularized log count data. If you are unfamiliar with principal component analysis, you might want to check the [Wikipedia entry](https://en.wikipedia.org/wiki/Principal_component_analysis) or this [interactive explanation](http://setosa.io/ev/principal-component-analysis/).
+The PCA plots below shows the distribution of samples in the study. They show  *experimental samples*, and do not include technical control samples, reference RNA samples, or experimental samples which were manually removed. These plots show the first two principal components that explain the variability in the data using the regularized log count data. If you are unfamiliar with principal component analysis, you might want to check the [Wikipedia entry](https://en.wikipedia.org/wiki/Principal_component_analysis) or this [interactive explanation](http://setosa.io/ev/principal-component-analysis/).
+
+## PCA all experimental samples
 
 Marker colour and shape are determined by the experimental groups defined in the config file. In the plot below, colour is determined by `r params$exp_groups[[1]][1]` and shape is determined by `r params$exp_groups[[1]][2]`. If your project has doses, they have been converted to dose levels, with 1 as the lowest.
 
@@ -433,6 +435,45 @@ p_pca_plotly <- plotly::ggplotly(p_pca, tooltip = "text")
 plotly::highlight(p_pca_plotly, on = "plotly_click", off = "plotly_doubleclick", color = "red")
 
 ```
+
+## PCA by batch
+
+If you have a batch variable specified in the config file, the plot below shows the distribution of samples in the study by batch. The plot is interactive. Click on a point to highlight it. Double-click to reset the plot.
+
+
+```{r pca_batch, fig.width = 9, fig.height = 8}
+
+if (!is.na(params$batch_var)) {
+    # Plot PCA with ggplot2
+  
+  batch_var <- params$batch_var
+
+  pca_data[[batch_var]] <- as.factor(pca_data[[batch_var]])
+  
+  p_pca_batch <- ggplot(pca_data, aes(x = PC1, 
+                                y = PC2, 
+                                color = !!sym(params$batch_var), 
+                                )) +
+    geom_point(size = 3,
+              aes(text = combined_label)) +
+    labs(title = "PCA of Experimental Samples",
+        x = paste0("PC1 (", round(100 * summary(pca_result)$importance[2, 1], 1), "%)"),
+        y = paste0("PC2 (", round(100 * summary(pca_result)$importance[2, 2], 1), "%)")) +
+    theme_minimal() +
+    scale_shape_manual(values = c(15, 16, 17, 18, 3, 7, 8, 10)) +
+    stat_ellipse(geom = "polygon", aes(group = !!sym(params$batch_var), fill = !!sym(params$batch_var)), alpha = 0.15, level = 0.99)
+
+  # Convert ggplot to plotly
+  p_pca_batch_plotly <- plotly::ggplotly(p_pca_batch, tooltip = "text")
+
+  # Add highlighting
+  plotly::highlight(p_pca_batch_plotly, on = "plotly_click", off = "plotly_doubleclick", color = "red")
+} else {
+  message("No batch variable specified in the config file.")
+}
+
+```
+
 
 # Correlations
 

--- a/Rmd/summary_report_new.Rmd
+++ b/Rmd/summary_report_new.Rmd
@@ -216,6 +216,10 @@ fail_dendro <- qc_info %>%
   dplyr::filter(dendrogram == "FAIL") %>%
   dplyr::select(sample_ID, params$dendro_color_by)
 
+fail_groupdendro <- qc_info %>%
+  dplyr::filter(group_dendrogram == "FAIL") %>%
+  dplyr::select(sample_ID, params$dendro_color_by)
+
 fail_nmr <- qc_info %>% 
   dplyr::filter(NMR == "FAIL") %>%
   dplyr::select(sample_ID, params$dendro_color_by)
@@ -240,10 +244,20 @@ fail_gic <- qc_info %>%
 ## Samples Failing Quality Control {.tabset .tabset-pills}
 
 
-### Clustering Distance
+### Clustering Distance (studywide)
 ```{r dendro_fail}
 fail_dendro %>%
   kable("html", caption = "Samples Failing Clustering Distance Filter") %>%
+  kable_styling(bootstrap_options = c("striped", "hover", "condensed", "responsive"))
+```
+
+<br>
+<br>
+
+### Clustering Distance (by group)
+```{r group_dendro_fail}
+fail_groupdendro %>%
+  kable("html", caption = "Samples Failing By-Group Clustering Distance Filter") %>%
   kable_styling(bootstrap_options = c("striped", "hover", "condensed", "responsive"))
 ```
 

--- a/workflow/modules/3-diffexp_and_reports.smk
+++ b/workflow/modules/3-diffexp_and_reports.smk
@@ -39,7 +39,7 @@ rule deseq2:
 rule deseq_reports:
     message: "generating DESeq2 reports in R..."
     input:
-        sm_temp_dir / "DESeq2_complete"
+        deseq2_complete = sm_temp_dir / "DESeq2_complete"
     output:
         touch(sm_temp_dir / "reports_complete")
     conda:
@@ -47,6 +47,7 @@ rule deseq_reports:
     benchmark: log_dir / "benchmark.deseq_report.txt"
     shell:
         '''
+        rm {input.deseq2_complete}
         Rscript scripts/render_DESeq2_report.parallel.R {analysis_folder}
 
         conda env export > output/analysis/{analysis_folder}/Pipeline_record/reports_env.yml


### PR DESCRIPTION
I found a few things to fix or upgrade while analyzing Ger's HMEC dataset. These commits:
- add a PCA coloured by batch to the studywide QC report, to help see batch effects
- fixes the vertically squished group dendrograms in the studywide QC report
- deletes a dummy file for DEseq2 when the reports are made, so that module 3 (diff_exp_and_reports) can be rerun, otherwise it errors out
- adds a missing tab from the summary report