### PR TITLE
Delete default channel

### DIFF
--- a/install.R
+++ b/install.R
@@ -1,3 +1,3 @@
 # Install extra dependencies
 chooseCRANmirror(1, graphics = FALSE)
-devtools::install_github("bwlewis/crosstool")
+devtools::install_github("bwlewis/crosstool", force = TRUE)

--- a/workflow/envs/base.yml
+++ b/workflow/envs/base.yml
@@ -4,7 +4,6 @@
 name: rodaf_base
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - bioconda::snakemake
   - conda-forge::setuptools<71 # Workaround for can't import from backports error

--- a/workflow/envs/preprocessing.yml
+++ b/workflow/envs/preprocessing.yml
@@ -2,7 +2,6 @@ name: R-ODAF_preprocessing
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - python=3.11
   - bioconda::rsem=1.3.3

--- a/workflow/envs/reports.yml
+++ b/workflow/envs/reports.yml
@@ -2,7 +2,6 @@ name: R-ODAF_reports
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - conda-forge::pandoc=2.19.2
   # R CRAN

--- a/workflow/envs/temposeqr.yml
+++ b/workflow/envs/temposeqr.yml
@@ -2,7 +2,6 @@ name: R-ODAF_temposeqr
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::samtools=1.16.1
   - bioconda::bioconductor-quasr=1.38.0


### PR DESCRIPTION
Remove default channel from environment defining yamls, to avoid using proprietary packages from anaconda.

Tested installing environment and running temposeq test dataset on VM without problems.