### PR TITLE
Optimize preprocessing threads

### DIFF
--- a/inputs/config/config.default.yaml
+++ b/inputs/config/config.default.yaml
@@ -31,7 +31,7 @@ pipeline:
   genome_name: "S1500_2.0" # used for labeling genome index files
   sample_id: "sample_ID" # header for the column for sample identifier in the metadata file.
   mode: se # one of 'se' (single end) or 'pe' (paired end)
-  threads: 8 # number of threads to use for multi-threaded programs
+  threads: 4 # number of threads to use for multi-threaded programs
 
 ###### QC parameters
 QC:

--- a/workflow/modules/1-preprocess_rnaseq.smk
+++ b/workflow/modules/1-preprocess_rnaseq.smk
@@ -2,8 +2,6 @@ include: "define.smk"
 include: "trim.smk"
 include: "align.smk"
 
-##### Dummy rule all for testing purposes
-##### Don't forget to change it!
 rule pp_rs_all:
     input: 
         processed_dir / "count_table.tsv",
@@ -43,11 +41,11 @@ if pipeline_config["mode"] == "pe":
         conda:
             "../envs/preprocessing.yml"
         params:
-            threads = workflow.cores,
+            threads = pipeline_config["threads"],
             output_prefix =  lambda wildcards : quant_dir / "{}".format(wildcards.sample),
             index_name = pipeline_config["genome_name"]
         benchmark: log_dir / "benchmark.{sample}.RSEM_pe.txt"
-        threads: workflow.cores
+        threads: pipeline_config["threads"]
         shell:
             '''
             rsem-calculate-expression \
@@ -70,11 +68,11 @@ if pipeline_config["mode"] == "se":
         conda:
             "../envs/preprocessing.yml"
         params:
-            threads = workflow.cores,
+            threads = pipeline_config["threads"],
             output_prefix =  lambda wildcards : quant_dir / "{}".format(wildcards.sample),
             index_name = pipeline_config["genome_name"]
         benchmark: log_dir / "benchmark.{sample}.RSEM_se.txt"
-        threads: workflow.cores
+        threads: pipeline_config["threads"]
         shell:
             '''
             rsem-calculate-expression \

--- a/workflow/modules/3-diffexp_and_reports.smk
+++ b/workflow/modules/3-diffexp_and_reports.smk
@@ -50,7 +50,7 @@ rule deseq_reports:
         rm {input.deseq2_complete}
         Rscript scripts/render_DESeq2_report.parallel.R {analysis_folder}
 
-        conda env export > output/analysis/{analysis_folder}/Pipeline_record/reports_env.yml
+        conda env export > output/analysis/{analysis_folder}/Pipeline_record/reports_env.yaml
         '''
 
 onerror:

--- a/workflow/modules/align.smk
+++ b/workflow/modules/align.smk
@@ -111,7 +111,7 @@ if pipeline_config["mode"] == "se":
             annotations = genome_dir / pipeline_config["annotation_filename"],
             folder = "{sample}",
             bam_prefix = lambda wildcards : align_dir / "{}.".format(wildcards.sample)
-        benchmark: log_dir / "benchmark.{sample}.STAR_pe.txt"
+        benchmark: log_dir / "benchmark.{sample}.STAR_se.txt"
         threads: num_threads
         shell:
             '''
@@ -152,7 +152,7 @@ if pipeline_config["mode"] == "pe":
             bam_prefix = lambda wildcards : align_dir / "{}.".format(wildcards.sample)
         resources:
             load=100
-        benchmark: log_dir / "benchmark.{sample}.STAR_se.txt"
+        benchmark: log_dir / "benchmark.{sample}.STAR_pe.txt"
         threads: num_threads
         shell:
             '''


### PR DESCRIPTION
I did some testing and found that running RSEM with fewer threads (but more parallel jobs) speeds up the preprocessing stage, which can be very long for RNA-Seq.

<img width="603" height="393" alt="image" src="https://github.com/user-attachments/assets/24037c30-f73f-4af8-b418-70c5f15a0b9a" />

Edited RSEM rules to use number of threads defined in config, and changed default config number of threads from 8 to 4.

Also changed two small things that have been driving me crazy (wrong file names in benchmark files, and an output file extension that causes errors when file is downloaded onto OneDrive).