### PR TITLE
Allow paired-end trimming; fix for annotation edge case

### DIFF
--- a/R.ODAF.utils/R/annotate_deseq_table.R
+++ b/R.ODAF.utils/R/annotate_deseq_table.R
@@ -30,32 +30,46 @@ annotate_deseq_table <- function(deseq_results_list,
     if (params$platform == "TempO-Seq") {
       deg_table <- dplyr::left_join(deg_table, params$biospyder, by = c("Feature_ID" = params$feature_id))
     } else {
-      tryCatch({
-        orgdb_path <- params$species_data$orgdb
-        if (!file.exists(orgdb_path)) {
-          stop("orgdb file not found at: ", orgdb_path)
-        }
-        orgdb <- AnnotationDbi::loadDb(orgdb_path)
+      # 1. Try to get annotations, returning NULL if anything goes wrong
+     annotations <- tryCatch({
 
-        annotations <- AnnotationDbi::select(
-          orgdb,
-          columns = c("ENSEMBL", "SYMBOL", "GENENAME"),
-          keys = feature_ids,
-          keytype = "ENSEMBL")
-        annotations <- dplyr::distinct(annotations, ENSEMBL, .keep_all = TRUE)
-        colnames(annotations) <- c("Feature_ID", "Gene_Symbol", "description")
-        deg_table <- deg_table %>% dplyr::mutate(Ensembl_Gene_ID = Feature_ID)
-        deg_table <- dplyr::left_join(deg_table, annotations, by = "Feature_ID")
-   }, error = function(e) {
-     message("Error during annotation: ", e$message)
-     deg_table <<- deg_table %>% 
-       dplyr::mutate(
-         Ensembl_Gene_ID = Feature_ID,
-         Gene_Symbol = NA_character_,
-         description = NA_character_
+      # Annotate using orgdb package for the species given in config
+      orgdb <- AnnotationDbi::loadDb(params$species_data$orgdb)
+
+      ann_df <- AnnotationDbi::select(
+        orgdb,
+        columns = c("ENSEMBL", "SYMBOL", "GENENAME"),
+        keys = feature_ids,
+        keytype = "ENSEMBL"
       )
+
+      # Ensure unique rows for annotations
+      ann_df <- dplyr::distinct(ann_df, ENSEMBL, .keep_all = TRUE)
+      colnames(ann_df) <- c("Feature_ID", "Gene_Symbol", "description")
+
+    # RETURN the dataframe to the 'annotations' variable
+    ann_df 
+
+  }, error = function(e) {
+    # If error, assign NULL to annotations
+    message("Warning: Annotation failed. Reason: ", e$message)
+    return(NULL)
   })
+
+  # 2. Prepare the base table
+  deg_table <- deg_table %>% dplyr::mutate(Ensembl_Gene_ID = Feature_ID)
+
+  # 3. Merge logic based on annotation success or failure
+  if (!is.null(annotations)) {
+    deg_table <- dplyr::left_join(deg_table, annotations, by = "Feature_ID")
+  } else {
+    # Fallback: Create columns with NA or Feature_ID
+    deg_table$Gene_Symbol <- deg_table$Feature_ID # Default to Feature_ID if no annotation
+    deg_table$description <- NA
+    deg_table$Ensembl_Gene_ID <- deg_table$Feature_ID
+    }
 }
+
     # Transform log2 fold changes into linear fold changes
     deg_table <- deg_table %>%
       dplyr::mutate(linearFoldChange = ifelse(log2FoldChange > 0, 2^log2FoldChange, -1 / (2^log2FoldChange)),
@@ -72,15 +86,15 @@ annotate_deseq_table <- function(deseq_results_list,
         contrast)
 
     # Apply biosets-specific filtering
-    if (biosets_filter) {
+    if (biosets_filter == TRUE) {
       deg_table <- deg_table[
         !is.na(deg_table$pvalue) &
           deg_table$pvalue < params$alpha &
           abs(deg_table$linearFoldChange) > params$linear_fc_filter_biosets, ]
     }
     return(deg_table %>% dplyr::distinct())
-  })
-
+  }
+  )
   # Combine the individual tables into one large table
   combined_results <- data.table::rbindlist(annotated_results, fill = TRUE)
   return(combined_results)

--- a/R.ODAF.utils/R/annotate_deseq_table.R
+++ b/R.ODAF.utils/R/annotate_deseq_table.R
@@ -31,20 +31,39 @@ annotate_deseq_table <- function(deseq_results_list,
       deg_table <- dplyr::left_join(deg_table, params$biospyder, by = c("Feature_ID" = params$feature_id))
     } else {
       # Annotation using orgdb package
+      annotations <- NULL # Initialize annotations to NULL
       tryCatch({
+        orgdb_path <- params$species_data$orgdb
+        if (!file.exists(orgdb_path)) {
+          stop("orgdb file not found at: ", orgdb_path)
+        }
+        orgdb <- AnnotationDbi::loadDb(orgdb_path)
+
         annotations <- AnnotationDbi::select(
-          AnnotationDbi::loadDb(params$species_data$orgdb),
+          orgdb,
           columns = c("ENSEMBL", "SYMBOL", "GENENAME"),
           keys = feature_ids,
           keytype = "ENSEMBL")
+        
         # Ensuring unique rows for annotations
         annotations <- dplyr::distinct(annotations, ENSEMBL, .keep_all = TRUE)
         colnames(annotations) <- c("Feature_ID", "Gene_Symbol", "description")
-        deg_table <- deg_table %>%  dplyr::mutate(Ensembl_Gene_ID = Feature_ID) # duplicate columns to prevent erroring out on last chunk
-        deg_table <- dplyr::left_join(deg_table, annotations, by = "Feature_ID")
+         # duplicate columns to prevent erroring out on last chunk
+        
       }, error = function(e) {
         message("Error during annotation: ", e$message)
       })
+    } ## NOTE only partway through implementing changes! 
+    deg_table <- deg_table %>%  dplyr::mutate(Ensembl_Gene_ID = Feature_ID)
+    
+    
+    if (!is.null(annotations)) {
+      deg_table <- dplyr::left_join(deg_table, annotations, by = "Feature_ID")
+    } else {
+      message("Warning: Annotation failed or returned no results for all Feature_IDs in this contrast. Adding placeholder columns.")
+      deg_table$Gene_Symbol <- deg_table$Feature_ID # Default to Feature_ID if no annotation
+      deg_table$description <- NA
+      deg_table$Ensembl_Gene_ID <- deg_table$Feature_ID
     }
 
     # Transform log2 fold changes into linear fold changes

--- a/workflow/modules/trim.smk
+++ b/workflow/modules/trim.smk
@@ -9,88 +9,89 @@ else:
     length_required_fastp = 36
     trim_tail1_fastp = 0
 
-rule fastp_se:
-    input:
-        R1 = ancient(str(raw_dir / "{sample}.fastq.gz"))
-    output:
-        R1 = trim_dir / "{sample}.fastq.gz", #put the pipes back in when done testing!
-        json = trim_dir / "{sample}_fastp.json",
-        html = trim_dir / "{sample}_fastp.html"
-    conda:
-        "../envs/preprocessing.yml"
-    params:
-        front_size = 1,
-        front_quality = 3,
-        tail_size = 1,
-        tail_quality = 3,
-        right_size = 4,
-        right_quality = 15,
-        length_required = length_required_fastp,
-        trim_tail1 = trim_tail1_fastp
-    benchmark: log_dir / "benchmark.{sample}.fastp_se.txt"
-    threads: num_threads
-    shell:
-        '''
-        fastp \
-        --in1 {input.R1} \
-        --out1 {output.R1} \
-        --json {output.json} \
-        --html {output.html} \
-        --cut_front \
-        --disable_adapter_trimming \
-        --cut_front_window_size {params.front_size} \
-        --cut_front_mean_quality {params.front_quality} \
-        --cut_tail \
-        --cut_tail_window_size {params.tail_size} \
-        --cut_tail_mean_quality {params.tail_quality} \
-        --cut_right \
-        --cut_right_window_size {params.right_size} \
-        --cut_right_mean_quality {params.right_quality} \
-        --length_required {params.length_required} \
-        --trim_tail1 {params.trim_tail1} \
-        --thread {threads} \
-        '''
+if pipeline_config["mode"] == "se":
+  rule fastp_se:
+      input:
+          R1 = ancient(str(raw_dir / "{sample}.fastq.gz"))
+      output:
+          R1 = trim_dir / "{sample}.fastq.gz", #put the pipes back in when done testing!
+          json = trim_dir / "{sample}_fastp.json",
+          html = trim_dir / "{sample}_fastp.html"
+      conda:
+          "../envs/preprocessing.yml"
+      params:
+          front_size = 1,
+          front_quality = 3,
+          tail_size = 1,
+          tail_quality = 3,
+          right_size = 4,
+          right_quality = 15,
+          length_required = length_required_fastp,
+          trim_tail1 = trim_tail1_fastp
+      benchmark: log_dir / "benchmark.{sample}.fastp_se.txt"
+      threads: num_threads
+      shell:
+          '''
+          fastp \
+          --in1 {input.R1} \
+          --out1 {output.R1} \
+          --json {output.json} \
+          --html {output.html} \
+          --cut_front \
+          --disable_adapter_trimming \
+          --cut_front_window_size {params.front_size} \
+          --cut_front_mean_quality {params.front_quality} \
+          --cut_tail \
+          --cut_tail_window_size {params.tail_size} \
+          --cut_tail_mean_quality {params.tail_quality} \
+          --cut_right \
+          --cut_right_window_size {params.right_size} \
+          --cut_right_mean_quality {params.right_quality} \
+          --length_required {params.length_required} \
+          --trim_tail1 {params.trim_tail1} \
+          --thread {threads} \
+          '''
 
-
-rule fastp_pe:
-    input:
-        R1 = ancient(str(raw_dir / "{sample}.R1.fastq.gz")),
-        R2 = ancient(str(raw_dir / "{sample}.R2.fastq.gz"))
-    output:
-        R1 = trim_dir / "{sample}.R1.fastq.gz", #put the pipes back in when done testing!
-        R2 = trim_dir / "{sample}.R2.fastq.gz", #put the pipes back in when done testing!
-        json = trim_dir / "{sample}_fastp.json",
-        html = trim_dir / "{sample}_fastp.html"
-    conda:
-        "../envs/preprocessing.yml"
-    params:
-        front_size = 1,
-        front_quality = 3,
-        tail_size = 1,
-        tail_quality = 3,
-        right_size = 4,
-        right_quality = 15,
-        length_required = length_required_fastp
-    benchmark: log_dir / "benchmark.{sample}.fastp_pe.txt"
-    threads: num_threads
-    shell:
-        '''
-        fastp \
-        --in1 {input.R1} \
-        --in2 {input.R2} \
-        --out1 {output.R1} \
-        --out2 {output.R2} \
-        --json {output.json} \
-        --html {output.html} \
-        --cut_front \
-        --cut_front_window_size {params.front_size} \
-        --cut_front_mean_quality {params.front_quality} \
-        --cut_tail \
-        --cut_tail_window_size {params.tail_size} \
-        --cut_tail_mean_quality {params.tail_quality} \
-        --cut_right \
-        --cut_right_window_size {params.right_size} \
-        --cut_right_mean_quality {params.right_quality} \
-        --length_required {params.length_required} \
-        --thread {threads} \
-        '''
+if pipeline_config["mode"] == "pe":
+  rule fastp_pe:
+      input:
+          R1 = ancient(str(raw_dir / "{sample}.R1.fastq.gz")),
+          R2 = ancient(str(raw_dir / "{sample}.R2.fastq.gz"))
+      output:
+          R1 = trim_dir / "{sample}.R1.fastq.gz", #put the pipes back in when done testing!
+          R2 = trim_dir / "{sample}.R2.fastq.gz", #put the pipes back in when done testing!
+          json = trim_dir / "{sample}_fastp.json",
+          html = trim_dir / "{sample}_fastp.html"
+      conda:
+          "../envs/preprocessing.yml"
+      params:
+          front_size = 1,
+          front_quality = 3,
+          tail_size = 1,
+          tail_quality = 3,
+          right_size = 4,
+          right_quality = 15,
+          length_required = length_required_fastp
+      benchmark: log_dir / "benchmark.{sample}.fastp_pe.txt"
+      threads: num_threads
+      shell:
+          '''
+          fastp \
+          --in1 {input.R1} \
+          --in2 {input.R2} \
+          --out1 {output.R1} \
+          --out2 {output.R2} \
+          --json {output.json} \
+          --html {output.html} \
+          --cut_front \
+          --cut_front_window_size {params.front_size} \
+          --cut_front_mean_quality {params.front_quality} \
+          --cut_tail \
+          --cut_tail_window_size {params.tail_size} \
+          --cut_tail_mean_quality {params.tail_quality} \
+          --cut_right \
+          --cut_right_window_size {params.right_size} \
+          --cut_right_mean_quality {params.right_quality} \
+          --length_required {params.length_required} \
+          --thread {threads} \
+          '''


### PR DESCRIPTION
This branch fixes a few problems discovered while analyzing the Macfarlane mouse RNA-seq dataset.

1. In preprocessing, snakemake couldn't sort out whether to use fastp_se or fastp_pe rule because file names were ambiguous. Now conditional checks for pipeline_config["mode"] to decide which rule.
2. In DEG annotation, if a contrast only has a single DEG and there's some issue with the annotation of it (ex. the ensembl ID is retired), pipeline breaks. There's a TryCatch to deal with this, except the next lines of code require the object created inside that trycatch to exists. Now placeholder columns are added to the DEG table if annotations are not available.

This addresses one of the problems also addressed (differently?) in PR #279 .

Currently tests fail so this is not ready to merge.