### PR TITLE
Improve env install

### DIFF
--- a/.github/workflows/temposeqtests.yml
+++ b/.github/workflows/temposeqtests.yml
@@ -79,9 +79,9 @@ jobs:
           mv temposeq/inputs .
           mv temposeq/truth_checksums .
           wget https://github.com/EHSRB-BSRSE-Bioinformatics/unify_temposeq_manifests/raw/main/output_manifests/Human_S1500_1.2_standardized.csv
-      - name: Run workflow, includes environments creation
+      - name: Run workflow, includes environment creation
         run: |
-          snakemake --cores 8 --sdm conda
+          snakemake --cores 8 --use-conda
       - name: Generate md5sums
         run: |
           md5sum output/processed/count_table.tsv > checksum.count_table

--- a/.github/workflows/temposeqtests.yml
+++ b/.github/workflows/temposeqtests.yml
@@ -79,33 +79,9 @@ jobs:
           mv temposeq/inputs .
           mv temposeq/truth_checksums .
           wget https://github.com/EHSRB-BSRSE-Bioinformatics/unify_temposeq_manifests/raw/main/output_manifests/Human_S1500_1.2_standardized.csv
-      - name: Build snakemake environment
+      - name: Run workflow, includes environments creation
         run: |
-          snakemake --cores 8 --use-conda --conda-create-envs-only
-      - name: Install extra dependencies
-        run: |
-         conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | \
-         sed s/\.yaml//) Rscript install.R
-      - name: Print env names
-        run: |
-          for yaml in .snakemake/conda/*.yaml; do
-            echo "$yaml:"
-            head -n 1 "$yaml"
-          done
-      - name: Print contents of Conda environments
-        run: |
-          for env in .snakemake/conda/*; do
-            if [ -d "$env" ]; then
-              echo "Contents of $env:"
-              conda activate $env
-              conda list
-              conda deactivate
-            fi
-          done
-        shell: bash -l {0}
-      - name: Run workflow
-        run: |
-          snakemake --cores 8 --use-conda
+          snakemake --cores 8 --sdm conda
       - name: Generate md5sums
         run: |
           md5sum output/processed/count_table.tsv > checksum.count_table

--- a/README.md
+++ b/README.md
@@ -94,34 +94,25 @@ To activate this environment:
 Other dependencies are managed by snakemake via the creation of conda environments. The conda environments needed for various steps of the workflow are defined in a series of .yml files in workflow/envs.
 
 
-
-### Installing environments
-__Environments must be installed *prior* to running the workflow__ because of additional dependencies that must be added to the R-ODAF_reports environment via the install.R script included in this repo. If you use snakemake to run the full workflow without first installing and fixing the environments, the workflow will not run to completion. This only needs to be done once per project, or once ever if you install environments [in a persistent location](####Persistent-environments). 
-
-From inside the repo directory, run:
-
-`snakemake --cores 32 --software-deployment-method conda --conda-create-envs-only`
-
-*Choose the number of cores according to what is available in your system.*
-
-Then install additional software in the reports environment: 
-
-`conda run -p $(grep -rl "R-ODAF_reports" .snakemake/conda/*.yaml | sed s/\.yaml//) Rscript install.R`
+### Creating environments
+Conda environments with the dependencies for each step of the pipeline will be created automatically the first time you run the pipeline. This can take some time.
+Note that this workflow requires the expected input data to exist before snakemake is run. If you want to install conda environments before preparing your input files, download the test dataset as explained in the "Running Tests" section below.
 
 #### Persistent environments
-If you intend to run this analysis on multiple datasets, it can be advantageous to instead install the environments in a persistent location, and point to this location with snakemake's --conda-prefix flag. This avoids having to install the environments multiple times, which saves both time and disk place.
+By default, conda environments will be created in a hidden subdirectory (.snakemake/conda).
+
+If you intend to run this analysis on multiple datasets, it can be advantageous to instead create the environments in a persistent location elsewhere in your filesystem, and point to this location with snakemake's --conda-prefix flag. This avoids having to install the environments in a new location each time you clone the repo, which saves both time and disk place.
 
 For example, the code below installs the environments in ~/snakemake_envs. Using this method, every time the analysis is run with snakemake, the command must include `--conda-prefix ~/snakemake_envs`
 
 ```
 mkdir ~/snakemake_envs #Place and name this directory as you wish, and use correctly later with --conda-prefix
 
-snakemake --cores 32 --software-deployment-method conda --conda-create-envs-only --conda-prefix ~/snakemake_envs/
-
-conda run -p $(grep -rl "R-ODAF_reports" ~/snakemake_envs/*.yaml | sed s/\.yaml//) Rscript install.R
+snakemake --cores 32 --software-deployment-method conda --conda-prefix ~/snakemake_envs/
 ```
 
 *When running the workflow, remember to use the --conda-prefix flag.*
+
 
 # Running tests
 It's a good idea to run a small test dataset through the workflow when you first install it. To do this:
@@ -144,7 +135,7 @@ Test run the pipeline (make sure you activate the snakemake environment first).
 
 `snakemake --sdm conda --cores 32 -n`
 
-If that works without error, actually run the pipeline.
+If that works without error, actually run the pipeline. Note that on the first run, conda environments will install unless you have installed them in a persistent location that you indicate with the --conda-prefix flag. Environment installation can take some time.
 
 `snakemake --sdm conda --cores 32`
 

--- a/workflow/envs/base.yml
+++ b/workflow/envs/base.yml
@@ -5,5 +5,5 @@ name: rodaf_base
 channels:
   - conda-forge
 dependencies:
-  - bioconda::snakemake
+  - bioconda::snakemake==8.0
   - conda-forge::setuptools<71 # Workaround for can't import from backports error

--- a/workflow/envs/base.yml
+++ b/workflow/envs/base.yml
@@ -5,5 +5,5 @@ name: rodaf_base
 channels:
   - conda-forge
 dependencies:
-  - bioconda::snakemake==8.0
+  - bioconda::snakemake
   - conda-forge::setuptools<71 # Workaround for can't import from backports error

--- a/workflow/envs/install_from_github.R
+++ b/workflow/envs/install_from_github.R
@@ -1,3 +1,3 @@
 # Install extra dependencies
 chooseCRANmirror(1, graphics = FALSE)
-devtools::install_github("bwlewis/crosstool", upgrade=never)
+devtools::install_github("bwlewis/crosstool", upgrade="never")

--- a/workflow/envs/install_from_github.R
+++ b/workflow/envs/install_from_github.R
@@ -1,3 +1,3 @@
 # Install extra dependencies
 chooseCRANmirror(1, graphics = FALSE)
-devtools::install_github("bwlewis/crosstool", force = TRUE)
+devtools::install_github("bwlewis/crosstool", upgrade=never)

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -3,10 +3,11 @@ set -o pipefail
 
 # This script runs after the reports environment is installed
 # And adds the crosstools package, which isn't available through conda
-conda activate -p $CONDA_PREFIX
 
 mkdir -p output/.rodaf_internal/install_logs
 
-(test -f output/.rodaf_internal/install_logs/myRscript.post-deploy.log || rm output/.rodaf_internal/install_logs/myRscript.post-deploy.log)
+# remove log file if it already exists
+rm -f output/.rodaf_internal/install_logs/install_from_github.post-deploy.log # Changed filename to match your redirect target.
 
-$CONDA_PREFIX/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1
+# Execute Rscript directly from the CONDA_PREFIX bin directory.
+"$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -23,6 +23,8 @@ if [ ! -f "$CONDA_PREFIX/bin/Rscript" ]; then
     exit 1 # Exit with an error
 fi
 
-"$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1
+# Remove output redirection to see Rscript errors directly
+"$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R
+
 echo "Rscript command finished."
 

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -1,0 +1,12 @@
+#!env bash
+set -o pipefail
+
+# This script runs after the reports environment is installed
+# And adds the crosstools package, which isn't available through conda
+conda activate -p $CONDA_PREFIX
+
+mkdir -p output/.rodaf_internal/install_logs
+
+(test -f output/.rodaf_internal/install_logs/myRscript.post-deploy.log || rm output/.rodaf_internal/install_logs/myRscript.post-deploy.log)
+
+$CONDA_PREFIX/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -1,4 +1,4 @@
-#!env bash
+#!/bin/bash
 set -o pipefail
 
 # This script runs after the reports environment is installed

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -1,10 +1,5 @@
-#!/bin/bash
+#!env bash
 set -euxo pipefail
-
-echo "--- DEBUG INFO ---"
-echo "Current PATH: $PATH"
-echo "CONDA_PREFIX: $CONDA_PREFIX"
-echo "--- END DEBUG INFO ---"
 
 # This script runs after the reports environment is installed
 # And adds the crosstools package, which isn't available through conda
@@ -12,19 +7,17 @@ echo "--- END DEBUG INFO ---"
 mkdir -p output/.rodaf_internal/install_logs
 
 # remove log file if it already exists
-echo "Attempting to remove install_from_github.post-deploy.log"
 rm -f output/.rodaf_internal/install_logs/install_from_github.post-deploy.log # Changed filename to match your redirect target.
 
-# Execute Rscript directly from the CONDA_PREFIX bin directory.
-# Check if Rscript exists before trying to run it
+# Check if Rscript exists in CONDA_PREFIX binbefore trying to run it
 if [ ! -f "$CONDA_PREFIX/bin/Rscript" ]; then
     echo "ERROR: Rscript not found at $CONDA_PREFIX/bin/Rscript"
     ls -l "$CONDA_PREFIX"/bin/R* # List R related executables
     exit 1 # Exit with an error
 fi
 
-# Remove output redirection to see Rscript errors directly
-"$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R
+# Run install script with logging
+"$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1
 
 echo "Rscript command finished."
 

--- a/workflow/envs/reports.post-deploy.sh
+++ b/workflow/envs/reports.post-deploy.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-set -o pipefail
+set -euxo pipefail
+
+echo "--- DEBUG INFO ---"
+echo "Current PATH: $PATH"
+echo "CONDA_PREFIX: $CONDA_PREFIX"
+echo "--- END DEBUG INFO ---"
 
 # This script runs after the reports environment is installed
 # And adds the crosstools package, which isn't available through conda
@@ -7,7 +12,17 @@ set -o pipefail
 mkdir -p output/.rodaf_internal/install_logs
 
 # remove log file if it already exists
+echo "Attempting to remove install_from_github.post-deploy.log"
 rm -f output/.rodaf_internal/install_logs/install_from_github.post-deploy.log # Changed filename to match your redirect target.
 
 # Execute Rscript directly from the CONDA_PREFIX bin directory.
+# Check if Rscript exists before trying to run it
+if [ ! -f "$CONDA_PREFIX/bin/Rscript" ]; then
+    echo "ERROR: Rscript not found at $CONDA_PREFIX/bin/Rscript"
+    ls -l "$CONDA_PREFIX"/bin/R* # List R related executables
+    exit 1 # Exit with an error
+fi
+
 "$CONDA_PREFIX"/bin/Rscript workflow/envs/install_from_github.R >> output/.rodaf_internal/install_logs/install_from_github.post-deploy.log 2>&1
+echo "Rscript command finished."
+


### PR DESCRIPTION
Replace the clunky old way of getting crosstools package into reports environment with a post-deployment script https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#providing-post-deployment-scripts . 

Now environments will be created and all dependencies downloaded, including ones from github, the first time snakemake is run. The README has been updated to reflect this change.

Had a bit of trouble with the github workflow, which turned out to be because of a missing set of quotes >.< . Sorry about all the github actions runs.