### PR TITLE
abort tgx reports if contrasts are complex

### DIFF
--- a/Rmd/tgx-hdaci.Rmd
+++ b/Rmd/tgx-hdaci.Rmd
@@ -159,6 +159,14 @@ if (is.na(params$deseq_facet) && !is.na(params$reports_facet)) {
 control <- contrasts_subset %>%
   dplyr::slice(1) %>%
   pull(V2)
+
+# If there is > 1 control across all contrasts, report will exit early
+n_controls <- contrasts_subset$V2 %>% unique() %>% length()
+
+if (n_controls > 1) {
+  message("This analysis can only be done when all contrasts have the same control. There are multiple controls in this set of contrasts. Fix coming soon (we hope).")
+  knitr::knit_exit()
+}
 ```
 
 ```{r get_IDs}

--- a/Rmd/tgx_ddi.Rmd
+++ b/Rmd/tgx_ddi.Rmd
@@ -159,6 +159,14 @@ if (is.na(params$deseq_facet) && !is.na(params$reports_facet)) {
 control <- contrasts_subset %>%
   slice(1) %>%
   pull(V2)
+
+# If there is > 1 control across all contrasts, report will exit early
+n_controls <- contrasts_subset$V2 %>% unique() %>% length()
+
+if (n_controls > 1) {
+  message("This analysis can only be done when all contrasts have the same control. There are multiple controls in this set of contrasts. Fix coming soon (we hope).")
+  knitr::knit_exit()
+}
 ```
 
 

--- a/scripts/render_DESeq2_report.parallel.R
+++ b/scripts/render_DESeq2_report.parallel.R
@@ -105,16 +105,22 @@ if (params$generate_tgxddi_report) {
     base::mapply(FUN = make_tgxddi_reports, facet = facets, MoreArgs = list(pars = params, paths = paths))
     # Concatenate all the TGxDDI output csv files into one
     tgxddi_files <- list.files(paths$reports_dir, pattern = "_tgx-ddi_results.csv", full.names = TRUE)
-    tgxddi_df <- readr::read_csv(tgxddi_files[1], show_col_types = FALSE)
-    if (length(tgxddi_files) > 1) {
-      for (i in 2:length(tgxddi_files)) {
-        tgxddi_df <- dplyr::bind_rows(tgxddi_df, readr::read_csv(tgxddi_files[i], show_col_types = FALSE))
+    
+    # Skip if no files found
+    if (length(tgxddi_files) == 0) {
+      message("No TGx-DDI results files found. Skipping concatenation.")
+    } else {
+      tgxddi_df <- readr::read_csv(tgxddi_files[1], show_col_types = FALSE)
+      if (length(tgxddi_files) > 1) {
+        for (i in 2:length(tgxddi_files)) {
+          tgxddi_df <- dplyr::bind_rows(tgxddi_df, readr::read_csv(tgxddi_files[i], show_col_types = FALSE))
+        }
       }
+      # Write out the concatenated file
+      readr::write_csv(tgxddi_df, file.path(paths$summary, paste0("tgx-ddi_results_summary.csv")))
+      # Delete the individual files
+      file.remove(tgxddi_files)
     }
-    # Write out the concatenated file
-    readr::write_csv(tgxddi_df, file.path(paths$summary, paste0("tgx-ddi_results_summary.csv")))
-    # Delete the individual files
-    file.remove(tgxddi_files)
   }
   else {
     message(paste("TGx-DDI analysis is only available for human datasets. Your parameters indicate that the data is from", params$species, ". Skipping TGx-DDI analysis."))
@@ -126,16 +132,22 @@ if (params$generate_tgxhdaci_report) {
     base::mapply(FUN = make_hdaci_reports, facet = facets, MoreArgs = list(pars = params, paths = paths))
     # Concatenate all the TGxHDACi output csv files into one
     tgxhdaci_files <- list.files(paths$reports_dir, pattern = "_tgx-HDACi_results.csv", full.names = TRUE)
-    tgxhdaci_df <- readr::read_csv(tgxhdaci_files[1], show_col_types = FALSE)
-    if (length(tgxhdaci_files) > 1) {
-      for (i in 2:length(tgxhdaci_files)) {
-        tgxhdaci_df <- dplyr::bind_rows(tgxhdaci_df, readr::read_csv(tgxhdaci_files[i], show_col_types = FALSE))
+
+    # Skip if no files found
+    if(length(tgxhdaci_files) == 0) {
+      message("No TGx-HDACi results files found.")
+    } else {
+      tgxhdaci_df <- readr::read_csv(tgxhdaci_files[1], show_col_types = FALSE)
+      if (length(tgxhdaci_files) > 1) {
+        for (i in 2:length(tgxhdaci_files)) {
+          tgxhdaci_df <- dplyr::bind_rows(tgxhdaci_df, readr::read_csv(tgxhdaci_files[i], show_col_types = FALSE))
+        }
       }
+      # Write out the concatenated file
+      readr::write_csv(tgxhdaci_df, file.path(paths$summary, paste0("tgx-hdaci_results_summary.csv")))
+      # Delete the individual files
+      file.remove(tgxhdaci_files)
     }
-    # Write out the concatenated file
-    readr::write_csv(tgxhdaci_df, file.path(paths$summary, paste0("tgx-hdaci_results_summary.csv")))
-    # Delete the individual files
-    file.remove(tgxhdaci_files)
   }
   else {
     message("TGx-HDACi report generation is currently only available for human datasets. Your parameters indicate that the data is from", params$species, ". Skipping TGx-HDACi analysis.")


### PR DESCRIPTION
Currently, the tgx-ddi and tgx-hdaci reports only work properly if all contrasts share the same control.

Example 1 (tgx analysis works correctly)

chem_1  DMSO
chem_2  DMSO
chem_3  DMSO

The code will use DMSO as the comparison for all.

Example 2 (tgx analysis will run, but results are incorrect)

chem_1  DMSO
chem_2  chem_1
chem_3  chem_1

The code will use DMSO as the comparison for all. The report will render just fine, and the results in it will _look_ real, but they will be incorrect.

This is because of the code in the  import_control_info chunk:
```
# Get the control from the contrasts (first contrast)
# This will only work if there's just one control for all the groups in the report
control <- contrasts_subset %>%
  dplyr::slice(1) %>%
  pull(V2)
```

I would like to rewrite the code to properly work for example 2, since that experimental design does happen sometimes. But for now, this PR stops incorrect results from being produced. A report is still made, but it will be a short html with a warning message in it. 


